### PR TITLE
chore: add needed files for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@
 node_modules/
 
 # These are generated files:
-/src/specification/spec.rs
 /local/*


### PR DESCRIPTION
It looks like we'll actually need this generated file for publishing. If the file is ignored we get an error on publishing commands that there is an uncommited file.