### PR TITLE
chore: add release workflows for crates and npm

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,19 @@
+name: Sync release branch
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  sync-branch:
+    name: Update release branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+      - name: Push to release branch
+        uses: connor-baer/action-sync-branch@main
+        with:
+          branch: release
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@
 
 name: release
 on:
-  workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * *
+  push:
+    branches:
+      - release
 
 jobs:
   release_to_crates:
@@ -17,6 +17,33 @@ jobs:
           cargo install cargo-release
       - name: Release crate
         run: cargo release --all-features --verbose minor
+      - name: Set git identity
+        run: |-
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+      - name: Open pull request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          author: github-actions <github-actions@github.com>
+          committer: github-actions <github-actions@github.com>
+          signoff: true
+          branch: release
+          body: |
+            Release cdk-from-cfn
+            Updates CloudFormation Specification. See details in [workflow run].
+
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit-message: |-
+            chore: upgrade cloudformation specification
+
+            Updates CloudFormation Specification. See details in [workflow run].
+
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          path: 'src/specification/spec.json'
+          title: 'chore: update cloudformation specification'
+          labels: auto-approve
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,57 +1,42 @@
 # .github/workflows/release.yml
 
+name: release
 on:
-  release:
-    types: [created]
-
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 0 * * *
 
 jobs:
-  release:
-    name: release ${{ matrix.target }} (with non-required env)
+  release_to_crates:
+    name: Release to crates.io
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-pc-windows-gnu
-            archive: zip
-          - target: x86_64-unknown-linux-musl
-            archive: tar.gz
-          - target: x86_64-apple-darwin
-            archive: zip
-          - target: wasm32-wasi
-            archive: zip tar.gz
     steps:
-      - uses: actions/checkout@master
-      - name: Compile and release
-        uses: rust-build/rust-build.action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: |-
+          curl https://sh.rustup.rs -sSf | sh
+          cargo install cargo-release
+      - name: Release crate
+        run: cargo release --all-features --verbose minor
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+  release_to_npm:
+    name: Release to npm
+    needs: release_to_crates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@main
         with:
-          RUSTTARGET: ${{ matrix.target }}
-          ARCHIVE_TYPES: ${{ matrix.archive }}
-  release_wasm_pack:
-    name: release wasm_pack version
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    steps:
-      - uses: actions/checkout@master
+          node-version: latest
       - uses: jetli/wasm-pack-action@v0.4.0
         name: Install wasm-pack
         with:
-          # Optional version of wasm-pack to install(eg. 'v0.9.1', 'latest')
-          version: 'latest'
-      - name: Build
-        run: wasm-pack build --all-features --target=nodejs --out-name=index
-      - name: Zip
-        run: (cd pkg && zip -r ../wasm-pack.zip .)
-      - name: Upload to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: '*.zip'
-          file_glob: true
-          tag: ${{ github.ref }}
-          overwrite: true
-          make_latest: false
+          version: latest
+      - name: Prepare Release
+        run: |-
+          wasm-pack build --all-features --target=nodejs --out-name=index
+      - name: Release
+        run: |-
+          npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
+          wasm-pack publish --tag latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ rust-version = "1.64"
 description = "Turn AWS CloudFormation templates into AWS CDK applications"
 license = "MIT OR Apache-2.0"
 
-include = [
-  "/src", "/docs", "LICENSE", "README.md", "CONTRIBUTING.md"
-]
-
 repository = "https://github.com/cdklabs/cdk-from-cfn"
 homepage = "https://github.com/cdklabs/cdk-from-cfn#readme"
 


### PR DESCRIPTION
Fixes https://github.com/cdklabs/cdk-from-cfn/issues/222

This change adds the release-sync workflow, which once per day will push any changes to the `release` branch.

On a push to that branch, the release workflow will increment the version, publish the new version to crates.io, tag the release commit, and then push the commit back to the release branch. It then creates an auto-approve PR to push the release back to main.

Lastly, the wasm-pack is built from the `release` and released to npm.
