### PR TITLE
chore: remove yarn install from build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,14 @@ jobs:
     name: Release to crates.io
     runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies
+      - name: Checkout
         uses: actions/checkout@main
       - name: Install cargo-release
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-release
           version: latest
-      - run: cargo release --all-features --verbose minor
+      - run: cargo release --all-features --verbose minor --execute
       - name: Set git identity
         run: |-
           git config user.name "github-actions"
@@ -32,6 +32,7 @@ jobs:
           committer: github-actions <github-actions@github.com>
           signoff: true
           branch: github-actions/release
+          base: main
           body: |
             Release cdk-from-cfn
 
@@ -51,6 +52,8 @@ jobs:
     needs: release_to_crates
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@main
       - name: Setup Node.js
         uses: actions/setup-node@main
         with:

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::io::Write;
-use std::process::Command;
 use std::{fs, io};
 
 use serde::Deserialize;
@@ -52,22 +51,6 @@ fn main() -> io::Result<()> {
             "pub const RESOURCE_TYPES: phf::Map<&'static str, phf::Map<&'static str, super::PropertyRule>> = {};",
             resource_types.build()
         )?;
-    }
-
-    // Install some TypeScript stuff in the right places for IDE comfort. Silently ignore if failing...
-    match Command::new("npm")
-        .args(["install", "--no-save", "aws-cdk-lib", "@types/node"])
-        .current_dir("tests/end-to-end")
-        .status()
-    {
-        Ok(npm_exit) => {
-            if !npm_exit.success() {
-                eprintln!("npm install failed with {npm_exit:?}");
-            }
-        }
-        Err(cause) => {
-            eprintln!("npm install failed with {cause:?}");
-        }
     }
 
     Ok(())


### PR DESCRIPTION
This is causing the release to fail because it generates node_modules and the cargo release command builds as part of the release. If fails upon detection of any changes not already committed.

This also contains a couple fixes to the release workflow.

Fixes #
