### PR TITLE
chore: replace `no_coverage` attribute with new `coverage` attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use indexmap::IndexMap;
 use parser::condition::ConditionFunction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, coverage(off))]
+#![cfg_attr(coverage_nightly, feature(no_coverage))]
 
 use indexmap::IndexMap;
 use parser::condition::ConditionFunction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage("off")))]
 
 use indexmap::IndexMap;
 use parser::condition::ConditionFunction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, feature(coverage("off")))]
+#![cfg_attr(coverage_nightly, coverage(off))]
 
 use indexmap::IndexMap;
 use parser::condition::ConditionFunction;

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -22,7 +22,7 @@ pub struct Typescript {
 }
 
 impl Typescript {
-    #[cfg_attr(coverage_nightly, no_coverage)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[deprecated(note = "Prefer using the Synthesizer API instead")]
     pub fn output(ir: CloudformationProgramIr) -> String {
         let mut output = Vec::new();


### PR DESCRIPTION
The `no_coverage` attribute has been replaced with a new `coverage` attribute that takes `on` or `off` as a parameter - see this (PR)[https://github.com/rust-lang/rust/pull/114656]. This PR makes this update.
