### PR TITLE
chore: add security audits

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,13 @@
+name: security-audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: rustsec/audit-check@main
+        with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -13,7 +13,7 @@ jobs:
     name: Lint and Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@main
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -37,11 +37,20 @@ jobs:
           command: clippy
           args: --manifest-path ./Cargo.toml -- -Adead-code -D warnings
 
+  security_audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: rustsec/audit-check@main
+        with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+
   testing:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@main
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -65,7 +74,7 @@ jobs:
     needs: [testing]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@vmain
       - name: Download CodeCov artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This adds a check to each individual PR as well as a daily check. The checks on individual PRs will ensure we don't merge anything with changes that include bad dependencies. It will fail the workflow so it cannot be merged. The cron job will cut an issue on a failure, in the case of emergent security advisories for dependencies we're already using.

Fixes #
