### PR TITLE
fix(java): default imports do not match CDK init templates

### DIFF
--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -422,7 +422,7 @@ impl Java {
 
 impl Default for Java {
     fn default() -> Self {
-        Self::new("com.acme.test.simple")
+        Self::new("com.myorg")
     }
 }
 

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -20,7 +20,7 @@ macro_rules! test_case {
             test_case!(
                 $name,
                 java,
-                &Java::new(concat!("com.acme.test.", stringify!($name))),
+                &Java::new(concat!("com.myorg")),
                 $stack_name,
                 "App.java"
             );

--- a/tests/end-to-end/simple/App.java
+++ b/tests/end-to-end/simple/App.java
@@ -1,4 +1,4 @@
-package com.acme.test.simple;
+package com.myorg;
 
 import software.constructs.Construct;
 

--- a/tests/end-to-end/vpc/App.java
+++ b/tests/end-to-end/vpc/App.java
@@ -1,4 +1,4 @@
-package com.acme.test.vpc;
+package com.myorg;
 
 import software.constructs.Construct;
 


### PR DESCRIPTION
Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
