### PR TITLE
chore: fix bug in python synth

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -421,10 +421,10 @@ impl Reference {
                 conditional: _,
                 attribute,
             } => format!(
-                "{var_name}{chain}attr{name}",
+                "{var_name}{chain}attr_{name}",
                 var_name = camel_case(&self.name),
                 chain = ".",
-                name = camel_case(attribute)
+                name = pretty_name(attribute)
             )
             .into(),
         }

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -125,7 +125,7 @@ class SimpleStack(Stack):
       bucket.addDependency(queue)
 
     # Outputs
-    self.bucket_arn = bucket.attrarn if is_us_east1 else None
+    self.bucket_arn = bucket.attr_arn if is_us_east1 else None
     if (is_us_east1):
       cdk.CfnOutput(self, 'BucketArn', 
         description = 'The ARN of the bucket in this template!',

--- a/tests/end-to-end/vpc/app.py
+++ b/tests/end-to-end/vpc/app.py
@@ -22,19 +22,19 @@ class VpcStack(Stack):
 
     subnet1 = ec2.CfnSubnet(self, 'Subnet1',
           availability_zone = cdk.Fn.select(0, cdk.Fn.getAzs('')),
-          cidr_block = cdk.Fn.select(0, cdk.Fn.cidr(vpc.attrcidrBlock, 6, str(8))),
+          cidr_block = cdk.Fn.select(0, cdk.Fn.cidr(vpc.attr_cidr_block, 6, str(8))),
           vpc_id = vpc.ref,
         )
 
     subnet2 = ec2.CfnSubnet(self, 'Subnet2',
           availability_zone = cdk.Fn.select(1, cdk.Fn.getAzs('')),
-          cidr_block = cdk.Fn.select(1, cdk.Fn.cidr(vpc.attrcidrBlock, 6, str(8))),
+          cidr_block = cdk.Fn.select(1, cdk.Fn.cidr(vpc.attr_cidr_block, 6, str(8))),
           vpc_id = vpc.ref,
         )
 
     subnet3 = ec2.CfnSubnet(self, 'Subnet3',
           availability_zone = cdk.Fn.select(2, cdk.Fn.getAzs('')),
-          cidr_block = cdk.Fn.select(2, cdk.Fn.cidr(vpc.attrcidrBlock, 6, str(8))),
+          cidr_block = cdk.Fn.select(2, cdk.Fn.cidr(vpc.attr_cidr_block, 6, str(8))),
           vpc_id = vpc.ref,
         )
 


### PR DESCRIPTION
Fixes the bug I was getting when deploying integ tests. Seems getatt was misformatting the attribute names

```
        File "/private/var/folders/7z/jm3q4jws2mdcjw47_sswyw0m0000gr/T/cdk-integ-0mw87ejmm3pg/cdktest-0mw87ejmm3pg-python-migrate-stack/cdktest_0mw87ejmm3pg_python_migrate_stack/cdktest_0mw87ejmm3pg_python_migrate_stack_stack.py", line 48, in __init__
          'value': myQueue.attrqueueName,
                   ^^^^^^^^^^^^^^^^^^^^^
      AttributeError: 'CfnQueue' object has no attribute 'attrqueueName'. Did you mean: 'attr_queue_name'?
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
