### PR TITLE
chore: make csharp props create when empty

### DIFF
--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -62,28 +62,26 @@ impl Synthesizer for CSharp {
         });
 
         // Props
-        if !ir.constructor.inputs.is_empty() {
-            let stack_props_class = namespace.indent_with_options(IndentOptions {
-                indent: INDENT,
-                leading: Some(format!("public class {stack_name}Props : StackProps\n{{").into()),
-                trailing: Some("}".into()),
-                trailing_newline: true,
-            });
+        let stack_props_class = namespace.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some(format!("public class {stack_name}Props : StackProps\n{{").into()),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
 
-            for param in &ir.constructor.inputs {
-                if let Some(description) = &param.description {
-                    stack_props_class.line("/// <summary>");
-                    for description_line in description.split('\n') {
-                        stack_props_class.line(format!("/// {description_line}"));
-                    }
-                    stack_props_class.line("/// </summary>");
+        for param in &ir.constructor.inputs {
+            if let Some(description) = &param.description {
+                stack_props_class.line("/// <summary>");
+                for description_line in description.split('\n') {
+                    stack_props_class.line(format!("/// {description_line}"));
                 }
-                stack_props_class.line(param.to_csharp_auto_property());
-                stack_props_class.newline();
+                stack_props_class.line("/// </summary>");
             }
-
-            namespace.newline();
+            stack_props_class.line(param.to_csharp_auto_property());
+            stack_props_class.newline();
         }
+
+        namespace.newline();
 
         // Description - comment before the stack class
         if let Some(descr) = ir.description {

--- a/tests/end-to-end/vpc/App.cs
+++ b/tests/end-to-end/vpc/App.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 
 namespace Com.Acme.Test.Simple
 {
+    public class VpcStackProps : StackProps
+    {
+    }
+
     public class VpcStack : Stack
     {
         public VpcStack(Construct scope, string id, VpcStackProps props = null) : base(scope, id, props)


### PR DESCRIPTION

Fixes 

```
      /private/var/folders/7z/jm3q4jws2mdcjw47_sswyw0m0000gr/T/cdk-integ-0453ig8l6lrx/cdktest-0453ig8l6lrx-csharp-migrate-stack/src/Cdktest0453Ig8L6LrxCsharpMigrateStack/Cdktest0453Ig8L6LrxCsharpMigrateStackStack.cs(28,87): error CS0246: The type or namespace name 'Cdktest0453Ig8L6LrxCsharpMigrateStackStackProps' could not be found (are you missing a using directive or an assembly reference?) [/private/var/folders/7z/jm3q4jws2mdcjw47_sswyw0m0000gr/T/cdk-integ-0453ig8l6lrx/cdktest-0453ig8l6lrx-csharp-migrate-stack/src/Cdktest0453Ig8L6LrxCsharpMigrateStack/Cdktest0453Ig8L6LrxCsharpMigrateStack.csproj]
      
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
