### PR TITLE
fix: exports not handled correctly

### DIFF
--- a/src/ir/outputs/mod.rs
+++ b/src/ir/outputs/mod.rs
@@ -35,11 +35,9 @@ impl OutputInstruction {
             let condition = output.condition;
             let description = output.description;
             let mut export: Option<ResourceIr> = None;
-            if let Some(x) = output.export {
-                if let ResourceValue::Object(x) = x {
-                    if let Some(x) = x.get_key_value("Name") {
-                        export = Some(resource_translator.translate(x.1.clone())?);
-                    }
+            if let Some(ResourceValue::Object(x)) = output.export {
+                if let Some(x) = x.get_key_value("Name") {
+                    export = Some(resource_translator.translate(x.1.clone())?);
                 }
             }
 

--- a/src/ir/outputs/mod.rs
+++ b/src/ir/outputs/mod.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 
 use crate::ir::resources::{ResourceIr, ResourceTranslator};
 use crate::parser::output::Output;
+use crate::parser::resource::ResourceValue;
 use crate::specification::{CfnType, Structure};
 use crate::TransmuteError;
 
@@ -33,10 +34,14 @@ impl OutputInstruction {
             let value = resource_translator.translate(output.value)?;
             let condition = output.condition;
             let description = output.description;
-            let export = match output.export {
-                Some(x) => Some(resource_translator.translate(x)?),
-                None => None,
-            };
+            let mut export: Option<ResourceIr> = None;
+            if let Some(x) = output.export {
+                if let ResourceValue::Object(x) = x {
+                    if let Some(x) = x.get_key_value("Name") {
+                        export = Some(resource_translator.translate(x.1.clone())?);
+                    }
+                }
+            }
 
             list.push(Self {
                 name,

--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -108,7 +108,8 @@ Outputs:
   BucketArn:
     Condition: IsUsEast1
     Description: The ARN of the bucket in this template!
-    Export: ExportName
+    Export: 
+      Name: ExportName
     Value:
       !GetAtt Bucket.Arn
 


### PR DESCRIPTION
The way Noctilucent is handling exports is not correct. 

**Background**

Exports in CFN look like this:
```
Outputs:
  BucketArn:
    Condition: IsUsEast1
    Description: The ARN of the bucket in this template!
    Export:
      Name: ExportName
```
NOT this:
```
Outputs:
  BucketArn:
    Condition: IsUsEast1
    Description: The ARN of the bucket in this template!
    Export: ExportName
```

**Bug**

If we give Noctilucent a template that looks like the first one today, it will produce incorrect CDK code:
```
new cdk.CfnOutput(this, 'BucketArn', {
    description: 'The ARN of the bucket in this template!',
    exportName: {
	name: 'ExportName'
    },
    value: this.bucketArn,
});
```
It should just use `exportName: 'ExportName'` without the extra level of nesting for the name.

**Fix**

To fix this, we can either change all the synthesizers (🙅‍♀️ ), or change how the IR represents exports (:grinning:).

The PR changes [this code in the IR](https://github.com/cdklabs/cdk-from-cfn/blob/main/src/ir/outputs/mod.rs#L36) to directly pass the value and not the full object containing `{ "Name": "Value" }`