### PR TITLE
fix: CSharp uses a different namespace than init template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> anyhow::Result<()> {
         #[cfg(feature = "java")]
         "java" => Box::<Java>::default(),
         #[cfg(feature = "csharp")]
-        "csharp" => Box::<CSharp>::default(),
+        "csharp" => Box::new(CSharp {}),
         unsupported => panic!("unsupported language: {}", unsupported),
     };
 

--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -17,23 +17,7 @@ use super::Synthesizer;
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("    ");
 
-pub struct CSharp {
-    namespace: String,
-}
-
-impl CSharp {
-    pub fn new(namespace: impl Into<String>) -> Self {
-        Self {
-            namespace: namespace.into(),
-        }
-    }
-}
-
-impl Default for CSharp {
-    fn default() -> Self {
-        Self::new("Com.Acme.Test.Simple")
-    }
-}
+pub struct CSharp {}
 
 impl Synthesizer for CSharp {
     fn synthesize(
@@ -56,7 +40,7 @@ impl Synthesizer for CSharp {
         // Namespace definition
         let namespace = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some(format!("namespace {}\n{{", self.namespace).into()),
+            leading: Some(format!("namespace {}\n{{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -32,7 +32,7 @@ macro_rules! test_case {
             test_case!($name, typescript, &Typescript {}, $stack_name, "app.ts");
 
             #[cfg(feature = "csharp")]
-            test_case!($name, csharp, &CSharp::default(), $stack_name, "App.cs");
+            test_case!($name, csharp, &CSharp {}, $stack_name, "App.cs");
         }
     };
 

--- a/tests/end-to-end/simple/App.cs
+++ b/tests/end-to-end/simple/App.cs
@@ -4,7 +4,7 @@ using Amazon.CDK.AWS.SQS;
 using Constructs;
 using System.Collections.Generic;
 
-namespace Com.Acme.Test.Simple
+namespace SimpleStack
 {
     public class SimpleStackProps : StackProps
     {

--- a/tests/end-to-end/vpc/App.cs
+++ b/tests/end-to-end/vpc/App.cs
@@ -3,7 +3,7 @@ using Amazon.CDK.AWS.EC2;
 using Constructs;
 using System.Collections.Generic;
 
-namespace Com.Acme.Test.Simple
+namespace VpcStack
 {
     public class VpcStackProps : StackProps
     {


### PR DESCRIPTION
The init'd CSharp app has a namespace conflict because the namespace in the generated app file is being created with the default namespace
```
namespace Com.Acme.Test.Simple
{
    public class Cdktest01Z00Mg0HtbkCsharpMigrateStackStackProps : StackProps
    {
    }

    /// <summary>
    /// AWS CloudFormation Sample Template SQS_With_CloudWatch_Alarms: Sample template showing how to create an SQS queue with AWS CloudWatch alarms on queue depth.
    /// </summary>
    public class Cdktest01Z00Mg0HtbkCsharpMigrateStackStack : Stack
    {
```
But the namespace of the program.cs file is using the stack name
```

namespace Cdktest01Z00Mg0HtbkCsharpMigrateStack
{
    sealed class Program
    {
        public static void Main(string[] args)
        {
            var app = new App();
            new Cdktest01Z00Mg0HtbkCsharpMigrateStackStack(app, "cdktest-01z00mg0htbk-csharp-migrate-stack", new StackProps
            {
```


I figured there were 2 ways to fix this. 
a) change the generated namespace to use the stack name
b) modify the init template to have `using namespace Com.Acme.Test.Simple`
I figured option a) was cleaner so that's what I did. I changed the implementation of CSharp to no longer use the Default/new design. It wasn't actually being used for anything so I just went ahead and deleted it and swapped out the use of the default for the stack name



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
