### PR TITLE
fix(go): wrong package name and referenced pointer instead of value

### DIFF
--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -305,14 +305,14 @@ impl Synthesizer for Golang {
 
         main_block.line("defer jsii.Close()");
         main_block.newline();
-        main_block.line("app := awscdk.NewApp(nil)");
+        main_block.line("app := cdk.NewApp(nil)");
         main_block.newline();
         let split_stack_name: Vec<&str> = stack_name.split("Stack").collect();
         main_block.line(format!(
-            "New{stack_name}(app, \"{}\", &{stack_name}Props{{",
+            "New{stack_name}(app, \"{}\", {stack_name}Props{{",
             split_stack_name[0]
         ));
-        main_block.indent(INDENT).line("awscdk.StackProps{");
+        main_block.indent(INDENT).line("cdk.StackProps{");
         main_block.indent(INDENT).indent(INDENT).line("Env: env(),");
         main_block.indent(INDENT).line("},");
         for param in &ir.constructor.inputs {
@@ -336,7 +336,7 @@ impl Synthesizer for Golang {
 
         let env_block = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("func env() *awscdk.Environment {".into()),
+            leading: Some("func env() *cdk.Environment {".into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -354,7 +354,7 @@ impl Synthesizer for Golang {
         env_block.line("// the stack to. This is the recommendation for production stacks.");
         env_block
             .line("//---------------------------------------------------------------------------");
-        env_block.line("// return &awscdk.Environment{");
+        env_block.line("// return &cdk.Environment{");
         env_block.line("//  Account: jsii.String(\"123456789012\"),");
         env_block.line("//  Region:  jsii.String(\"us-east-1\"),");
         env_block.line("// }");
@@ -365,7 +365,7 @@ impl Synthesizer for Golang {
         env_block.line("// stacks.");
         env_block
             .line("//---------------------------------------------------------------------------");
-        env_block.line("// return &awscdk.Environment{");
+        env_block.line("// return &cdk.Environment{");
         env_block.line("//  Account: jsii.String(os.Getenv(\"CDK_DEFAULT_ACCOUNT\")),");
         env_block.line("//  Region:  jsii.String(os.Getenv(\"CDK_DEFAULT_REGION\")),");
         env_block.line("// }");

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -178,10 +178,10 @@ func ifCondition[T any](cond bool, whenTrue T, whenFalse T) T {
 func main() {
 	defer jsii.Close()
 
-	app := awscdk.NewApp(nil)
+	app := cdk.NewApp(nil)
 
-	NewSimpleStack(app, "Simple", &SimpleStackProps{
-		awscdk.StackProps{
+	NewSimpleStack(app, "Simple", SimpleStackProps{
+		cdk.StackProps{
 			Env: env(),
 		},
 		BucketNamePrefix: "bucket",
@@ -193,7 +193,7 @@ func main() {
 
 // env determines the AWS environment (account+region) in which our stack is to
 // be deployed. For more information see: https://docs.aws.amazon.com/cdk/latest/guide/environments.html
-func env() *awscdk.Environment {
+func env() *cdk.Environment {
 	// If unspecified, this stack will be "environment-agnostic".
 	// Account/Region-dependent features and context lookups will not work, but a
 	// single synthesized template can be deployed anywhere.
@@ -203,7 +203,7 @@ func env() *awscdk.Environment {
 	// Uncomment if you know exactly what account and region you want to deploy
 	// the stack to. This is the recommendation for production stacks.
 	//---------------------------------------------------------------------------
-	// return &awscdk.Environment{
+	// return &cdk.Environment{
 	//  Account: jsii.String("123456789012"),
 	//  Region:  jsii.String("us-east-1"),
 	// }
@@ -212,7 +212,7 @@ func env() *awscdk.Environment {
 	// implied by the current CLI configuration. This is recommended for dev
 	// stacks.
 	//---------------------------------------------------------------------------
-	// return &awscdk.Environment{
+	// return &cdk.Environment{
 	//  Account: jsii.String(os.Getenv("CDK_DEFAULT_ACCOUNT")),
 	//  Region:  jsii.String(os.Getenv("CDK_DEFAULT_REGION")),
 	// }

--- a/tests/end-to-end/vpc/app.go
+++ b/tests/end-to-end/vpc/app.go
@@ -72,10 +72,10 @@ func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *Vp
 func main() {
 	defer jsii.Close()
 
-	app := awscdk.NewApp(nil)
+	app := cdk.NewApp(nil)
 
-	NewVpcStack(app, "Vpc", &VpcStackProps{
-		awscdk.StackProps{
+	NewVpcStack(app, "Vpc", VpcStackProps{
+		cdk.StackProps{
 			Env: env(),
 		},
 	})
@@ -85,7 +85,7 @@ func main() {
 
 // env determines the AWS environment (account+region) in which our stack is to
 // be deployed. For more information see: https://docs.aws.amazon.com/cdk/latest/guide/environments.html
-func env() *awscdk.Environment {
+func env() *cdk.Environment {
 	// If unspecified, this stack will be "environment-agnostic".
 	// Account/Region-dependent features and context lookups will not work, but a
 	// single synthesized template can be deployed anywhere.
@@ -95,7 +95,7 @@ func env() *awscdk.Environment {
 	// Uncomment if you know exactly what account and region you want to deploy
 	// the stack to. This is the recommendation for production stacks.
 	//---------------------------------------------------------------------------
-	// return &awscdk.Environment{
+	// return &cdk.Environment{
 	//  Account: jsii.String("123456789012"),
 	//  Region:  jsii.String("us-east-1"),
 	// }
@@ -104,7 +104,7 @@ func env() *awscdk.Environment {
 	// implied by the current CLI configuration. This is recommended for dev
 	// stacks.
 	//---------------------------------------------------------------------------
-	// return &awscdk.Environment{
+	// return &cdk.Environment{
 	//  Account: jsii.String(os.Getenv("CDK_DEFAULT_ACCOUNT")),
 	//  Region:  jsii.String(os.Getenv("CDK_DEFAULT_REGION")),
 	// }


### PR DESCRIPTION
Fixes 
```
      ./cdktest-0jwrczbk9hlf-go-migrate-stack.go:46:9: undefined: awscdk
      ./cdktest-0jwrczbk9hlf-go-migrate-stack.go:48:81: cannot use &Cdktest0Jwrczbk9HlfGoMigrateStackStackProps{…} (value of type *Cdktest0Jwrczbk9HlfGoMigrateStackStackProps) as Cdktest0Jwrczbk9HlfGoMigrateStackStackProps value in argument to NewCdktest0Jwrczbk9HlfGoMigrateStackStack
      ./cdktest-0jwrczbk9hlf-go-migrate-stack.go:49:3: undefined: awscdk
      ./cdktest-0jwrczbk9hlf-go-migrate-stack.go:59:13: undefined: awscdk
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
