### PR TITLE
fix(python): resource attribute formatting uses camel case

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -487,7 +487,7 @@ fn emit_resource_attributes(
     if let Some(metadata) = &reference.metadata {
         let md = output.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some(format!("{var_name}.cfnOptions.metadata = {{").into()),
+            leading: Some(format!("{var_name}.cfn_options.metadata = {{").into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -495,13 +495,13 @@ fn emit_resource_attributes(
     }
 
     if let Some(update_policy) = &reference.update_policy {
-        output.text(format!("{var_name}.cfnOptions.updatePolicy = "));
+        output.text(format!("{var_name}.cfn_options.update_policy = "));
         emit_resource_ir(context, output, update_policy, Some(""));
     }
 
     if let Some(deletion_policy) = &reference.deletion_policy {
         output.line(format!(
-            "{var_name}.cfnOptions.deletionPolicy = cdk.CfnDeletionPolicy.{deletion_policy}"
+            "{var_name}.cfn_options.deletion_policy = cdk.CfnDeletionPolicy.{deletion_policy}"
         ));
     }
 

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -118,10 +118,10 @@ class SimpleStack(Stack):
           ],
         ) if is_us_east1 else None
     if (bucket is not None):
-      bucket.cfnOptions.metadata = {
+      bucket.cfn_options.metadata = {
         CostCenter: 1337,
       }
-      bucket.cfnOptions.deletionPolicy = cdk.CfnDeletionPolicy.RETAIN
+      bucket.cfn_options.deletion_policy = cdk.CfnDeletionPolicy.RETAIN
       bucket.addDependency(queue)
 
     # Outputs


### PR DESCRIPTION
Fixes 
```
  File "/Users/bobertzh/work/deleteme/temp/GoodPython/good_python/good_python_stack.py", line 30, in __init__
    s3Bucket.cfnOptions.deletionPolicy = cdk.CfnDeletionPolicy.RETAIN
    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'CfnBucket' object has no attribute 'cfnOptions'. Did you mean: 'cfn_options'?
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
