### PR TITLE
fix(csharp): StackProps are renamed when no stack props are present

### DIFF
--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -99,13 +99,19 @@ impl Synthesizer for CSharp {
             stack_class.newline();
         }
 
+        let props_name: String = if ir.constructor.inputs.is_empty() {
+            "StackProps".to_string()
+        } else {
+            format!("{stack_name}Props").to_string()
+        };
+
         // Constructor
         let ctor = stack_class.indent_with_options(IndentOptions {
             indent: INDENT,
             leading: Some(format!(
-                "public {}(Construct scope, string id, {}Props props = null) : base(scope, id, props)\n{{",
+                "public {}(Construct scope, string id, {} props = null) : base(scope, id, props)\n{{",
                 stack_name,
-                stack_name
+                props_name
             ).into()),
             trailing: Some("}".into()),
             trailing_newline: true,

--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -46,26 +46,28 @@ impl Synthesizer for CSharp {
         });
 
         // Props
-        let stack_props_class = namespace.indent_with_options(IndentOptions {
-            indent: INDENT,
-            leading: Some(format!("public class {stack_name}Props : StackProps\n{{").into()),
-            trailing: Some("}".into()),
-            trailing_newline: true,
-        });
+        if !ir.constructor.inputs.is_empty() {
+            let stack_props_class = namespace.indent_with_options(IndentOptions {
+                indent: INDENT,
+                leading: Some(format!("public class {stack_name}Props : StackProps\n{{").into()),
+                trailing: Some("}".into()),
+                trailing_newline: true,
+            });
 
-        for param in &ir.constructor.inputs {
-            if let Some(description) = &param.description {
-                stack_props_class.line("/// <summary>");
-                for description_line in description.split('\n') {
-                    stack_props_class.line(format!("/// {description_line}"));
+            for param in &ir.constructor.inputs {
+                if let Some(description) = &param.description {
+                    stack_props_class.line("/// <summary>");
+                    for description_line in description.split('\n') {
+                        stack_props_class.line(format!("/// {description_line}"));
+                    }
+                    stack_props_class.line("/// </summary>");
                 }
-                stack_props_class.line("/// </summary>");
+                stack_props_class.line(param.to_csharp_auto_property());
+                stack_props_class.newline();
             }
-            stack_props_class.line(param.to_csharp_auto_property());
-            stack_props_class.newline();
-        }
 
-        namespace.newline();
+            namespace.newline();
+        }
 
         // Description - comment before the stack class
         if let Some(descr) = ir.description {

--- a/tests/end-to-end/resource_w_json_type_properties/App.cs
+++ b/tests/end-to-end/resource_w_json_type_properties/App.cs
@@ -6,13 +6,9 @@ using System.Collections.Generic;
 
 namespace JsonPropsStack
 {
-    public class JsonPropsStackProps : StackProps
-    {
-    }
-
     public class JsonPropsStack : Stack
     {
-        public JsonPropsStack(Construct scope, string id, JsonPropsStackProps props = null) : base(scope, id, props)
+        public JsonPropsStack(Construct scope, string id, StackProps props = null) : base(scope, id, props)
         {
 
             // Resources

--- a/tests/end-to-end/vpc/App.cs
+++ b/tests/end-to-end/vpc/App.cs
@@ -7,7 +7,7 @@ namespace VpcStack
 {
     public class VpcStack : Stack
     {
-        public VpcStack(Construct scope, string id, VpcStackProps props = null) : base(scope, id, props)
+        public VpcStack(Construct scope, string id, StackProps props = null) : base(scope, id, props)
         {
 
             // Resources

--- a/tests/end-to-end/vpc/App.cs
+++ b/tests/end-to-end/vpc/App.cs
@@ -5,10 +5,6 @@ using System.Collections.Generic;
 
 namespace VpcStack
 {
-    public class VpcStackProps : StackProps
-    {
-    }
-
     public class VpcStack : Stack
     {
         public VpcStack(Construct scope, string id, VpcStackProps props = null) : base(scope, id, props)


### PR DESCRIPTION
We should only be renaming `StackProps` when there are props present. If none are, we just won't add the structure or rename the stack props.

This is also how Java is structured.

This is part 1 of the fix but it will unblock the tests in the CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
