### PR TITLE
fix(csharp): import statements are incorrectly cased

### DIFF
--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -11,7 +11,7 @@ use crate::parser::lookup_table::MappingInnerValue;
 use crate::specification::{CfnType, Structure};
 use std::borrow::Cow;
 use std::io;
-use voca_rs::case::{camel_case, pascal_case};
+use voca_rs::case::{camel_case, pascal_case, upper_case};
 
 use super::Synthesizer;
 
@@ -300,16 +300,13 @@ impl ImportInstruction {
         if self.path.len() > 1 {
             for submodule_part in self.path[1].split('-') {
                 parts.push(match submodule_part {
-                    "aws" => "AWS".into(),
-                    // TODO - This is hardcoded for now.
-                    // This part of the namespace needs to be pulled from the jsiirc.json
-                    // of the submodule. In C# there is no consistent rule we can apply to transform
-                    // this string to have the right casing.
-                    // Some are all caps, and some are Pascal case.
-                    "s3" => "S3".into(),
-                    "sqs" => "SQS".into(),
-                    "ec2" => "EC2".into(),
-                    other => other.into(),
+                    part => {
+                        if part.len() <= 3 {
+                            upper_case(part).into()
+                        } else {
+                            pascal_case(part).into()
+                        }
+                    }
                 });
             }
         }

--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -406,9 +406,13 @@ impl CsharpEmitter for Reference {
             Origin::GetAttribute {
                 attribute,
                 conditional: _,
-            } => output.text(format!("{}.Attr{attribute}", camel_case(&self.name))),
+            } => output.text(format!(
+                "{}.Attr{}",
+                camel_case(&self.name),
+                attribute.replace('.', "")
+            )),
             Origin::LogicalId { conditional: _ } => {
-                output.text(format!("{}.Ref", camel_case(&self.name)))
+                output.text(format!("{}.Ref", camel_case(&self.name.replace('.', ""))))
             }
             Origin::Parameter => output.text(format!("props.{}", pascal_case(&self.name))),
             Origin::PseudoParameter(pseudo) => {

--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -299,14 +299,10 @@ impl ImportInstruction {
 
         if self.path.len() > 1 {
             for submodule_part in self.path[1].split('-') {
-                parts.push(match submodule_part {
-                    part => {
-                        if part.len() <= 3 {
-                            upper_case(part).into()
-                        } else {
-                            pascal_case(part).into()
-                        }
-                    }
+                parts.push(if submodule_part.len() <= 3 {
+                    upper_case(submodule_part).into()
+                } else {
+                    pascal_case(submodule_part).into()
                 });
             }
         }

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -550,21 +550,35 @@ impl Inspectable for ResourceIr {
 
 impl ImportInstruction {
     fn to_golang(&self) -> String {
-        let mut parts: Vec<Cow<str>> = vec![match self.path[0].as_str() {
-            "aws-cdk-lib" => "github.com/aws/aws-cdk-go/awscdk/v2".into(),
-            other => other.into(),
-        }];
-        parts.extend(self.path[1..].iter().map(|item| {
-            item.chars()
-                .filter(|ch| ch.is_alphanumeric())
-                .collect::<String>()
-                .into()
-        }));
+        let mut parts: Vec<String> = vec![
+            "github.com".to_string(),
+            "aws".to_string(),
+            "aws-cdk-go".to_string(),
+            "awscdk".to_string(),
+            "v2".to_string(),
+        ];
+        match self.organization.as_str() {
+            "AWS" => match &self.service {
+                Some(service) => {
+                    parts.push(format!("aws{}", service.to_lowercase()));
+                }
+                None => {}
+            },
+            "Alexa" => parts.push(format!(
+                "alexa{}",
+                self.service.as_ref().unwrap().to_lowercase()
+            )),
+            _ => unreachable!(),
+        }
 
         format!(
-            "{name} {module:?}",
-            name = self.name,
-            module = parts.join("/")
+            "{} \"{}\"",
+            &self
+                .service
+                .as_ref()
+                .unwrap_or(&"cdk".to_string())
+                .to_lowercase(),
+            parts.join("/")
         )
     }
 }

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -912,9 +912,10 @@ enum IdentifierKind {
 /// Computes a go identifier name that is a suitable representation of the given
 /// name.
 fn golang_identifier(text: &str, kind: IdentifierKind) -> String {
+    let text_string = text.replace('.', "");
     match kind {
-        IdentifierKind::Exported => pascal_case(text),
-        IdentifierKind::ModuleName => snake_case(text),
-        IdentifierKind::Unexported => camel_case(text),
+        IdentifierKind::Exported => pascal_case(&text_string),
+        IdentifierKind::ModuleName => snake_case(&text_string),
+        IdentifierKind::Unexported => camel_case(&text_string),
     }
 }

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -587,10 +587,14 @@ fn emit_reference(reference: Reference) -> String {
                     "Optional.of({}.isPresent() ? {}.get().getAttr{}()\n{DOUBLE_INDENT}: Optional.empty())",
                     camel_case(&name),
                     camel_case(&name),
-                    pascal_case(&attribute)
+                    pascal_case(&attribute.replace('.', ""))
                 )
             } else {
-                format!("{}.getAttr{}()", camel_case(&name), pascal_case(&attribute))
+                format!(
+                    "{}.getAttr{}()",
+                    camel_case(&name),
+                    pascal_case(&attribute.replace('.', ""))
+                )
             }
         }
         Origin::PseudoParameter(param) => get_pseudo_param(param),

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -9,8 +9,8 @@ use crate::parser::lookup_table::MappingInnerValue;
 use crate::parser::resource::DeletionPolicy;
 use crate::specification::Structure;
 use std::borrow::Cow;
-use std::io;
 use std::rc::Rc;
+use std::{io, vec};
 use voca_rs::case::{camel_case, pascal_case};
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("    ");
@@ -51,11 +51,11 @@ impl Java {
         code.line("import software.constructs.Construct;");
         code.newline();
         code.line("import java.util.*;");
-        code.line("import software.amazon.awscdk.*;");
         code.line("import software.amazon.awscdk.CfnMapping;");
         code.line("import software.amazon.awscdk.CfnTag;");
         code.line("import software.amazon.awscdk.Stack;");
         code.line("import software.amazon.awscdk.StackProps;");
+        code.newline();
     }
 
     fn emit_mappings(mapping: &MappingInnerValue, output: &CodeBuffer) {
@@ -490,32 +490,28 @@ impl Synthesizer for Java {
 
 impl ImportInstruction {
     fn to_java_import(&self) -> String {
-        let mut parts: Vec<Cow<str>> = vec![match self.path[0].as_str() {
-            "aws-cdk-lib" => "software.amazon.awscdk.services".into(),
-            other => other.into(),
-        }];
-        parts.extend(self.path[1..].iter().map(|item| {
-            item.chars()
-                .filter(|ch| ch.is_alphanumeric())
-                .collect::<String>()
-                .into()
-        }));
-
-        let module = parts
-            .iter()
-            .take(parts.len() - 1)
-            .map(|part| part.to_string())
-            .collect::<Vec<_>>()
-            .join(".");
-        if !module.is_empty() {
-            format!(
-                "import {module}.{name}.*;",
-                module = module,
-                name = self.name,
-            )
-        } else {
-            "".to_string()
+        let mut parts: Vec<String> = vec![
+            "software".to_string(),
+            "amazon".to_string(),
+            "awscdk".to_string(),
+        ];
+        match self.organization.as_str() {
+            "AWS" => {
+                match &self.service {
+                    Some(service) => {
+                        parts.push("services".to_string());
+                        parts.push(service.to_lowercase());
+                    }
+                    None => {}
+                };
+            }
+            "Alexa" => {
+                parts.push("alexa".to_string());
+                parts.push(self.service.as_ref().unwrap().to_lowercase());
+            }
+            _ => unreachable!(),
         }
+        format!("import {}.*;", parts.join("."))
     }
 }
 

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -230,30 +230,25 @@ fn emit_cfn_output(
 
 impl ImportInstruction {
     fn to_python(&self) -> String {
-        let mut parts: Vec<String> = vec![match self.path[0].as_str() {
-            "aws-cdk-lib" => "aws_cdk".to_string(),
-            other => other.to_string(),
-        }];
-
-        // mapping all - in imports to _ is a bit hacky but it should always be fine
-        parts.extend(self.path[1..].iter().map(|item| {
-            item.chars()
-                .map(|ch| if ch == '-' { '_' } else { ch })
-                .filter(|ch| ch.is_alphanumeric() || *ch == '_')
-                .collect::<String>()
-        }));
-
-        let module = parts.join(".");
-        if !module.is_empty() {
-            // lambda is a reserved keyword in python. If we encounter it or another keyword, we prepend 'aws_'
-            if KEYWORDS.contains(&self.name.as_str()) {
-                format!("import {} as aws_{}", module, self.name,)
-            } else {
-                format!("import {} as {}", module, self.name,)
+        let import = match self.organization.as_str() {
+            "AWS" => match &self.service {
+                Some(service) => {
+                    let s = service.to_lowercase();
+                    if KEYWORDS.contains(&s.as_str()) {
+                        format!("import aws_cdk.aws_{s} as aws_{s}").to_string()
+                    } else {
+                        format!("import aws_cdk.aws_{s} as {s}").to_string()
+                    }
+                }
+                None => "import aws_cdk as cdk".to_string(),
+            },
+            "Alexa" => {
+                let s = self.service.as_ref().unwrap().to_lowercase();
+                format!("import alexa_{s} as ask from {s}").to_string()
             }
-        } else {
-            "".to_string()
-        }
+            _ => unreachable!(),
+        };
+        import
     }
 }
 

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -287,7 +287,7 @@ fn pretty_name(name: &str) -> String {
         }
         pretty.push(ch.to_lowercase().next().unwrap());
     }
-    pretty
+    pretty.replace('.', "")
 }
 
 trait PythonCodeBuffer {

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -336,7 +336,7 @@ impl Reference {
                 "{var_name}{chain}attr{name}",
                 var_name = camel_case(&self.name),
                 chain = if *conditional { "?." } else { "." },
-                name = pascal_case(attribute)
+                name = pascal_case(&attribute.replace('.', ""))
             )
             .into(),
         }

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -1,6 +1,7 @@
 use crate::code::{CodeBuffer, IndentOptions};
 use crate::ir::conditions::ConditionIr;
 use crate::ir::constructor::ConstructorParameter;
+use crate::ir::importer::ImportInstruction;
 use crate::ir::mappings::{MappingInstruction, OutputType};
 use crate::ir::outputs::OutputInstruction;
 use crate::ir::reference::{Origin, PseudoParameter, Reference};
@@ -17,21 +18,7 @@ use super::Synthesizer;
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("  ");
 
-pub struct Typescript {
-    // TODO: Put options in here for different outputs in typescript
-}
-
-impl Typescript {
-    #[cfg_attr(coverage_nightly, coverage(off))]
-    #[deprecated(note = "Prefer using the Synthesizer API instead")]
-    pub fn output(ir: CloudformationProgramIr) -> String {
-        let mut output = Vec::new();
-        Typescript {}
-            .synthesize(ir, &mut output, "NoctStack")
-            .unwrap();
-        String::from_utf8(output).unwrap()
-    }
-}
+pub struct Typescript {}
 
 impl Synthesizer for Typescript {
     fn synthesize(
@@ -44,11 +31,7 @@ impl Synthesizer for Typescript {
 
         let imports = code.section(true);
         for import in &ir.imports {
-            imports.line(format!(
-                "import * as {} from '{}';",
-                import.name,
-                import.path.join("/"),
-            ));
+            imports.line(import.to_typescript())
         }
 
         let context = &mut TypescriptContext::with_imports(imports);
@@ -285,6 +268,32 @@ impl Synthesizer for Typescript {
         }
 
         code.write(output)
+    }
+}
+
+impl ImportInstruction {
+    fn to_typescript(&self) -> String {
+        let mut parts: Vec<String> = vec!["aws-cdk-lib".to_string()];
+        match self.organization.as_str() {
+            "AWS" => match &self.service {
+                Some(service) => parts.push(format!("aws-{}", service.to_lowercase())),
+                None => {}
+            },
+            "Alexa" => parts.push(format!(
+                "alexa-{}",
+                self.service.as_ref().unwrap().to_lowercase()
+            )),
+            _ => unreachable!(),
+        }
+
+        format!(
+            "import * as {} from '{}';",
+            self.service
+                .as_ref()
+                .unwrap_or(&"cdk".to_string())
+                .to_lowercase(),
+            parts.join("/")
+        )
     }
 }
 

--- a/tests/end-to-end/config/App.cs
+++ b/tests/end-to-end/config/App.cs
@@ -1,10 +1,10 @@
 using Amazon.CDK;
-using Amazon.CDK.AWS.config;
+using Amazon.CDK.AWS.Config;
 using Amazon.CDK.AWS.EC2;
-using Amazon.CDK.AWS.iam;
-using Amazon.CDK.AWS.lambda;
+using Amazon.CDK.AWS.IAM;
+using Amazon.CDK.AWS.Lambda;
 using Amazon.CDK.AWS.S3;
-using Amazon.CDK.AWS.sns;
+using Amazon.CDK.AWS.SNS;
 using Constructs;
 using System.Collections.Generic;
 

--- a/tests/end-to-end/config/App.java
+++ b/tests/end-to-end/config/App.java
@@ -3,12 +3,12 @@ package com.myorg;
 import software.constructs.Construct;
 
 import java.util.*;
-import software.amazon.awscdk.*;
 import software.amazon.awscdk.CfnMapping;
 import software.amazon.awscdk.CfnTag;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
 
+import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.config.*;
 import software.amazon.awscdk.services.ec2.*;
 import software.amazon.awscdk.services.iam.*;

--- a/tests/end-to-end/documentdb/App.cs
+++ b/tests/end-to-end/documentdb/App.cs
@@ -1,5 +1,5 @@
 using Amazon.CDK;
-using Amazon.CDK.AWS.docdb;
+using Amazon.CDK.AWS.DocDB;
 using Constructs;
 using System.Collections.Generic;
 

--- a/tests/end-to-end/documentdb/App.java
+++ b/tests/end-to-end/documentdb/App.java
@@ -3,12 +3,12 @@ package com.myorg;
 import software.constructs.Construct;
 
 import java.util.*;
-import software.amazon.awscdk.*;
 import software.amazon.awscdk.CfnMapping;
 import software.amazon.awscdk.CfnTag;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
 
+import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.docdb.*;
 
 class DocumentDbStack extends Stack {

--- a/tests/end-to-end/resource_w_json_type_properties/App.cs
+++ b/tests/end-to-end/resource_w_json_type_properties/App.cs
@@ -1,5 +1,5 @@
 using Amazon.CDK;
-using Amazon.CDK.AWS.iam;
+using Amazon.CDK.AWS.IAM;
 using Amazon.CDK.AWS.SQS;
 using Constructs;
 using System.Collections.Generic;

--- a/tests/end-to-end/resource_w_json_type_properties/App.java
+++ b/tests/end-to-end/resource_w_json_type_properties/App.java
@@ -3,12 +3,12 @@ package com.myorg;
 import software.constructs.Construct;
 
 import java.util.*;
-import software.amazon.awscdk.*;
 import software.amazon.awscdk.CfnMapping;
 import software.amazon.awscdk.CfnTag;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
 
+import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.iam.*;
 import software.amazon.awscdk.services.sqs.*;
 

--- a/tests/end-to-end/simple/App.java
+++ b/tests/end-to-end/simple/App.java
@@ -3,12 +3,12 @@ package com.myorg;
 import software.constructs.Construct;
 
 import java.util.*;
-import software.amazon.awscdk.*;
 import software.amazon.awscdk.CfnMapping;
 import software.amazon.awscdk.CfnTag;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
 
+import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.s3.*;
 import software.amazon.awscdk.services.sqs.*;
 

--- a/tests/end-to-end/vpc/App.java
+++ b/tests/end-to-end/vpc/App.java
@@ -3,12 +3,12 @@ package com.myorg;
 import software.constructs.Construct;
 
 import java.util.*;
-import software.amazon.awscdk.*;
 import software.amazon.awscdk.CfnMapping;
 import software.amazon.awscdk.CfnTag;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
 
+import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.ec2.*;
 
 class VpcStack extends Stack {


### PR DESCRIPTION
This required quite a bit of refactoring since the default case we were using was for typescript. We shouldn't be setting those defaults in IR so I removed it and handled the language specific logic in each language synthesizer.
    
This change legitimately fixes the issue for all use cases (or at least every one we have in the cdk library.

Fixes https://github.com/cdklabs/cdk-from-cfn/issues/214

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
