### PR TITLE
fix: incorrectly formatted python joins

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -618,8 +618,8 @@ fn emit_resource_ir(
         ResourceIr::Join(sep, list) => {
             let items = output.indent_with_options(IndentOptions {
                 indent: INDENT,
-                leading: Some("[".into()),
-                trailing: Some(format!("].join('{sep}')", sep = sep.escape_debug()).into()),
+                leading: Some(format!("'{sep}'.join([", sep = sep.escape_debug()).into()),
+                trailing: Some("])".into()),
                 trailing_newline: false,
             });
             for item in list {

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -87,11 +87,11 @@ class SimpleStack(Stack):
           delay_seconds = 42.1337,
           fifo_queue = False,
           kms_master_key_id = cdk.Fn.importValue('Shared.KmsKeyArn'),
-          queue_name = [
+          queue_name = '-'.join([
             self.stackName,
             strings['Bars']['Bar'],
             cdk.Fn.select(1, cdk.Fn.getAzs(self.region)),
-          ].join('-'),
+          ]),
           redrive_policy = None,
           visibility_timeout = 120,
         )


### PR DESCRIPTION
Fixes #

Python joins were:
```
    self.s3_bucket_secure_u_r_l = [
      'https://',
      s3Bucket.attr_domain_name,
    ].join('')
```
Which is not how python does joins. They are now:
```
''.join([
      'https://',
      s3Bucket.attr_domain_name,
    ])
```
which is how python does joins

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
