### PR TITLE
fix(python): python reserved keywords overlapping with service names

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -244,10 +244,9 @@ impl ImportInstruction {
         let module = parts.join(".");
         if !module.is_empty() {
             // "lambda" is a reserved keyword in python, so we need to change it to aws_lambda
-            if self.name == "lambda"{
+            if self.name == "lambda" {
                 format!("import {} as aws_{}", module, self.name,)
-            }
-            else {
+            } else {
                 format!("import {} as {}", module, self.name,)
             }
         } else {

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -446,8 +446,7 @@ fn emit_resource(
     let service: String;
     if reference.resource_type.service().to_lowercase() == "lambda" {
         service = format!("aws_{}", reference.resource_type.service().to_lowercase());
-    }
-    else {
+    } else {
         service = reference.resource_type.service().to_lowercase();
     }
 

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -243,7 +243,13 @@ impl ImportInstruction {
 
         let module = parts.join(".");
         if !module.is_empty() {
-            format!("import {} as {}", module, self.name,)
+            // "lambda" is a reserved keyword in python, so we need to change it to aws_lambda
+            if self.name == "lambda"{
+                format!("import {} as aws_{}", module, self.name,)
+            }
+            else {
+                format!("import {} as {}", module, self.name,)
+            }
         } else {
             "".to_string()
         }
@@ -437,7 +443,14 @@ fn emit_resource(
     reference: &ResourceInstruction,
 ) {
     let var_name = camel_case(&reference.name);
-    let service = reference.resource_type.service().to_lowercase();
+    // "lambda" is a reserved keyword in python, so we need to change it to aws_lambda
+    let service: String;
+    if reference.resource_type.service().to_lowercase() == "lambda" {
+        service = format!("aws_{}", reference.resource_type.service().to_lowercase());
+    }
+    else {
+        service = reference.resource_type.service().to_lowercase();
+    }
 
     let maybe_undefined = if let Some(cond) = &reference.condition {
         output.line(format!(

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -19,13 +19,10 @@ use super::Synthesizer;
 const INDENT: Cow<'static, str> = Cow::Borrowed("  ");
 
 const KEYWORDS: &[&str] = &[
-    "False", "await", "else", "import", "pass",
-    "None", "break", "except", "in", "raise",
-    "True", "class", "finally", "is", "return",
-    "and", "continue", "for", "lambda", "try",
-    "as", "def", "from", "nonlocal", "while",
-    "assert", "del", "global", "not", "with",
-    "async", "elif", "if", "or", "yield"
+    "False", "await", "else", "import", "pass", "None", "break", "except", "in", "raise", "True",
+    "class", "finally", "is", "return", "and", "continue", "for", "lambda", "try", "as", "def",
+    "from", "nonlocal", "while", "assert", "del", "global", "not", "with", "async", "elif", "if",
+    "or", "yield",
 ];
 
 pub struct Python {}

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -443,13 +443,10 @@ fn emit_resource(
 ) {
     let var_name = camel_case(&reference.name);
     // "lambda" is a reserved keyword in python, so we need to change it to aws_lambda
-    let service: String;
-    if reference.resource_type.service().to_lowercase() == "lambda" {
+    let mut service: String = reference.resource_type.service().to_lowercase();
+    if service == "lambda" {
         service = format!("aws_{}", reference.resource_type.service().to_lowercase());
-    } else {
-        service = reference.resource_type.service().to_lowercase();
     }
-
     let maybe_undefined = if let Some(cond) = &reference.condition {
         output.line(format!(
             "{var_name} = {service}.Cfn{rtype}(self, '{}',",

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -18,6 +18,16 @@ use super::Synthesizer;
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("  ");
 
+const KEYWORDS: &[&str] = &[
+    "False", "await", "else", "import", "pass",
+    "None", "break", "except", "in", "raise",
+    "True", "class", "finally", "is", "return",
+    "and", "continue", "for", "lambda", "try",
+    "as", "def", "from", "nonlocal", "while",
+    "assert", "del", "global", "not", "with",
+    "async", "elif", "if", "or", "yield"
+];
+
 pub struct Python {}
 
 impl Synthesizer for Python {
@@ -243,8 +253,8 @@ impl ImportInstruction {
 
         let module = parts.join(".");
         if !module.is_empty() {
-            // "lambda" is a reserved keyword in python, so we need to change it to aws_lambda
-            if self.name == "lambda" {
+            // lambda is a reserved keyword in python. If we encounter it or another keyword, we prepend 'aws_'
+            if KEYWORDS.contains(&self.name.as_str()) {
                 format!("import {} as aws_{}", module, self.name,)
             } else {
                 format!("import {} as {}", module, self.name,)
@@ -442,9 +452,9 @@ fn emit_resource(
     reference: &ResourceInstruction,
 ) {
     let var_name = camel_case(&reference.name);
-    // "lambda" is a reserved keyword in python, so we need to change it to aws_lambda
+    // lambda is a reserved keyword in python. If we encounter it or another keyword, we prepend 'aws_'
     let mut service: String = reference.resource_type.service().to_lowercase();
-    if service == "lambda" {
+    if KEYWORDS.contains(&service.as_str()) {
         service = format!("aws_{}", reference.resource_type.service().to_lowercase());
     }
     let maybe_undefined = if let Some(cond) = &reference.condition {


### PR DESCRIPTION
Previously python apps would fail lambda because we would be using the keyword lambda. i.e.
```
import aws_cdk.aws_lambda as lambda

lambdaFunction = lambda.CfnFunction(self, 'LambdaFunction'
```

fixed by only adding `aws_` before a lambda import
```
import aws_cdk.aws_lambda as aws_lambda

lambdaFunction = aws_lambda.CfnFunction(self, 'LambdaFunction'
```

Fixes # https://github.com/cdklabs/cdk-from-cfn/issues/319

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
