### PR TITLE
fix(java): removal policy uses different enum values than other languages

### DIFF
--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -6,6 +6,7 @@ use crate::ir::reference::{Origin, PseudoParameter, Reference};
 use crate::ir::resources::{ResourceInstruction, ResourceIr};
 use crate::ir::CloudformationProgramIr;
 use crate::parser::lookup_table::MappingInnerValue;
+use crate::parser::resource::DeletionPolicy;
 use crate::specification::Structure;
 use std::borrow::Cow;
 use std::io;
@@ -295,12 +296,26 @@ impl Java {
             extra_line = true;
         }
 
+        // Madness. Why is Java DESTROY instead of DELETE?
+
         if let Some(deletion_policy) = &resource.deletion_policy {
-            writer.text(format!(
-                "{res_name}.applyRemovalPolicy(RemovalPolicy.{deletion_policy}){}",
-                trailer
-            ));
-            extra_line = true;
+            // Madness
+            match deletion_policy {
+                DeletionPolicy::Delete => {
+                    writer.text(format!(
+                        "{res_name}.applyRemovalPolicy(RemovalPolicy.DESTROY){}",
+                        trailer
+                    ));
+                    extra_line = true;
+                }
+                _ => {
+                    writer.text(format!(
+                        "{res_name}.applyRemovalPolicy(RemovalPolicy.{deletion_policy}){}",
+                        trailer
+                    ));
+                    extra_line = true;
+                }
+            }
         }
 
         if let Some(update_policy) = &resource.update_policy {


### PR DESCRIPTION


This is bad and Java should feel bad. Java doesn't use DELETE as a RemovalPolicy value and uses DESTROY instead.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
