### PR TITLE
fix(all): booleans are processed as strings causing failures

### DIFF
--- a/src/ir/constructor/mod.rs
+++ b/src/ir/constructor/mod.rs
@@ -14,8 +14,27 @@ impl Constructor {
                 .map(|(name, param)| ConstructorParameter {
                     name: camel_case(&name),
                     description: param.description,
-                    constructor_type: param.parameter_type.to_string(),
+                    constructor_type: match param.parameter_type {
+                        crate::parser::parameters::ParameterType::String => {
+                            if param.allowed_values.is_some() {
+                                let values = param.allowed_values.clone().unwrap();
+                                if (values[0].to_lowercase() == "true"
+                                    && values[1].to_lowercase() == "false")
+                                    || (values[1].to_lowercase() == "true"
+                                        && values[0].to_lowercase() == "false")
+                                {
+                                    crate::parser::parameters::ParameterType::Bool.to_string()
+                                } else {
+                                    param.parameter_type.to_string()
+                                }
+                            } else {
+                                param.parameter_type.to_string()
+                            }
+                        }
+                        _ => param.parameter_type.to_string(),
+                    },
                     default_value: param.default,
+                    allowed_values: param.allowed_values,
                 })
                 .collect(),
         }
@@ -27,6 +46,7 @@ pub struct ConstructorParameter {
     pub description: Option<String>,
     pub constructor_type: String,
     pub default_value: Option<String>,
+    pub allowed_values: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/ir/constructor/tests.rs
+++ b/src/ir/constructor/tests.rs
@@ -39,6 +39,7 @@ fn test_constructor_from() {
         constructor.inputs[0].default_value,
         Some("default1".to_string())
     );
+    assert_eq!(constructor.inputs[0].allowed_values, None);
 
     assert_eq!(constructor.inputs[1].name, "param2");
     assert_eq!(
@@ -47,6 +48,7 @@ fn test_constructor_from() {
     );
     assert_eq!(constructor.inputs[1].constructor_type, "Number");
     assert_eq!(constructor.inputs[1].default_value, None);
+    assert_eq!(constructor.inputs[1].allowed_values, None);
 }
 
 #[test]
@@ -56,10 +58,15 @@ fn test_constructor_parameter() {
         description: Some("description1".to_string()),
         constructor_type: "String".to_string(),
         default_value: Some("default1".to_string()),
+        allowed_values: Some(vec!["true".to_string(), "false".to_string()]),
     };
 
     assert_eq!(param.name, "Param1");
     assert_eq!(param.description, Some("description1".to_string()));
     assert_eq!(param.constructor_type, "String");
     assert_eq!(param.default_value, Some("default1".to_string()));
+    assert_eq!(
+        param.allowed_values,
+        Some(vec!["true".to_string(), "false".to_string()])
+    );
 }

--- a/src/parser/parameters/mod.rs
+++ b/src/parser/parameters/mod.rs
@@ -17,6 +17,7 @@ pub enum ParameterType {
     #[serde(rename = "List<Number>")]
     ListOfNumbers,
     CommaDelimitedList,
+    Bool,
     #[serde(other)]
     Other(String),
 }
@@ -29,6 +30,7 @@ impl fmt::Display for ParameterType {
             ParameterType::ListOfNumbers => write!(f, "List<Number>"),
             ParameterType::CommaDelimitedList => write!(f, "CommaDelimitedList"),
             ParameterType::Other(s) => write!(f, "{}", s),
+            ParameterType::Bool => write!(f, "Boolean"),
         }
     }
 }

--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -173,6 +173,7 @@ impl Synthesizer for CSharp {
                                         .collect::<Vec<String>>()
                                         .join(",")
                                 ),
+                                "Boolean" => value.clone(),
                                 _ => value.clone(),
                             };
                             value
@@ -323,6 +324,7 @@ impl ConstructorParameter {
     fn to_csharp_auto_property(&self) -> String {
         let prop_type = match &self.constructor_type {
             t if t.contains("List") => "string[]",
+            t if t == "Boolean" => "bool",
             _ => "string",
         };
 

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -96,6 +96,7 @@ impl Java {
             let java_type = match input.constructor_type.as_str() {
                 "List<Number>" => "List<Number>",
                 t if t.contains("List") => "String[]",
+                "Boolean" => "Boolean",
                 _ => "String",
             };
 
@@ -103,7 +104,11 @@ impl Java {
                 name: input.name.clone(),
                 description: input.description.clone(),
                 java_type: java_type.into(),
-                constructor_type: input.constructor_type.clone(),
+                constructor_type: if java_type == "Boolean" {
+                    "Boolean".to_string()
+                } else {
+                    input.constructor_type.clone()
+                },
                 default_value: input.default_value.clone(),
             });
         }
@@ -206,9 +211,13 @@ impl Java {
                     prop_details.line(".build()");
                     prop_details.line(format!(".{}();", value_as));
                 }
+                Some(v) if prop.constructor_type == ("Boolean") => writer.line(format!(
+                    "{} = Optional.ofNullable({}).isPresent() ? {}\n{DOUBLE_INDENT}: {v};",
+                    prop.name, prop.name, prop.name
+                )),
                 Some(v) => writer.line(format!(
-                    "{} = Optional.ofNullable({}).isPresent() ? {}\n{DOUBLE_INDENT}: \"{}\";",
-                    prop.name, prop.name, prop.name, v
+                    "{} = Optional.ofNullable({}).isPresent() ? {}\n{DOUBLE_INDENT}: \"{v}\";",
+                    prop.name, prop.name, prop.name
                 )),
             }
         }

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -84,6 +84,7 @@ impl Synthesizer for Typescript {
             let constructor_type = match param.constructor_type.as_str() {
                 "List<Number>" => "number[]",
                 t if t.contains("List") => "string[]",
+                "Boolean" => "boolean",
                 _ => "string",
             };
             iface_props.line(format!(

--- a/tests/end-to-end/documentdb/template.yml
+++ b/tests/end-to-end/documentdb/template.yml
@@ -1,0 +1,80 @@
+Description:  "AWS CloudFormation Sample Template DocumentDB_Quick_Create: Sample template showing how to create a DocumentDB DB cluster and DB instance. **WARNING** This template creates an Amazon DocumentDB resources and you will be billed for the AWS resources used if you create a stack from this template."
+
+Parameters: 
+  DBClusterName: 
+    Default: "MyCluster"
+    Description : "Cluster name"
+    Type: "String"
+    MinLength: "1"
+    MaxLength: "64"
+    AllowedPattern : "[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*"
+    ConstraintDescription : "Must begin with a letter and contain only alphanumeric characters."
+
+  DBInstanceName: 
+    Default: "MyInstance"
+    Description : "Instance name"
+    Type: "String"
+    MinLength: "1"
+    MaxLength: "64"
+    AllowedPattern : "[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*"
+    ConstraintDescription : "Must begin with a letter and contain only alphanumeric characters."
+
+  MasterUser:
+    NoEcho: "true"
+    Description : "The database admin account username"
+    Type: "String"
+    MinLength: "1"
+    MaxLength: "16"
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription : "Must begin with a letter and contain only alphanumeric characters."
+
+  MasterPassword:
+    NoEcho: "true"
+    Description : "The database admin account password"
+    Type: "String"
+    MinLength: "1"
+    MaxLength: "41"
+    AllowedPattern : "[a-zA-Z0-9]+"
+    ConstraintDescription : "must contain only alphanumeric characters."
+
+  DBInstanceClass:
+    Description : "Instance class. Please refer to: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-classes-by-region"
+    Type: "String"
+    AllowedValues:
+      - db.t3.medium
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
+      - db.r5.24xlarge                             
+    ConstraintDescription : "Instance type must be of the ones supported for the region. Please refer to: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-classes-by-region"  
+
+Resources:
+  DBCluster:
+    Type: "AWS::DocDB::DBCluster"
+    DeletionPolicy: Delete
+    Properties:
+      DBClusterIdentifier: !Ref DBClusterName
+      MasterUsername: !Ref MasterUser
+      MasterUserPassword: !Ref MasterPassword
+      EngineVersion: 4.0.0
+
+  DBInstance:
+    Type: "AWS::DocDB::DBInstance"
+    Properties:
+      DBClusterIdentifier: !Ref DBCluster
+      DBInstanceIdentifier: !Ref DBInstanceName
+      DBInstanceClass: !Ref DBInstanceClass
+    DependsOn: DBCluster
+
+Outputs:
+  ClusterId:
+    Value: !Ref DBCluster
+  ClusterEndpoint:
+    Value: !GetAtt DBCluster.Endpoint
+  ClusterPort:
+    Value: !GetAtt DBCluster.Port
+  EngineVersion:
+    Value: "4.0.0"
+


### PR DESCRIPTION
When "AllowedValues" in the CloudFormation template is populated and the allowed values are "true" and "false", the CDK translates these props into a boolean instead of a string. However, when other allowed values are present, the prop should still be represented as a string. 

As before, I have not included the tests, as before, because they're not fully passing yet but I've attached the template that I'm working against for reference. This template contains an example of allowed values that should resolve to a string, while the last template I uploaded translates allowed values that should resolve to a boolean.

Fixes https://github.com/cdklabs/cdk-from-cfn/issues/318

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
