### PR TITLE
fix(python): python outputs weren't very pythonic

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -168,7 +168,6 @@ impl Synthesizer for Python {
                     let comment = ctor.pydoc();
                     comment.line(description.to_owned());
                 }
-                ctor.newline();
                 if let Some(cond) = &cond {
                     ctor.text(format!("self.{var_name} = "));
                     emit_resource_ir(context, &ctor, &op.value, Some(""));
@@ -189,6 +188,7 @@ impl Synthesizer for Python {
                 } else {
                     emit_cfn_output(context, &ctor, op, &var_name);
                 }
+                ctor.newline();
             }
         }
 

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -48,17 +48,6 @@ impl Synthesizer for Python {
             trailing: Some("".into()),
             trailing_newline: true,
         });
-        if !ir.outputs.is_empty() {
-            for op in &ir.outputs {
-                if let Some(description) = &op.description {
-                    let comment = class.pydoc();
-                    comment.line(description.to_owned());
-                }
-                // NOTE: the property type can be inferred by the compiler...
-                class.line(format!("global {name}", name = pretty_name(&op.name)));
-            }
-            class.newline();
-        }
 
         let ctor = class.indent_with_options(IndentOptions {
             indent: INDENT,
@@ -175,7 +164,11 @@ impl Synthesizer for Python {
             for op in &ir.outputs {
                 let var_name = pretty_name(&op.name);
                 let cond = op.condition.as_ref().map(|s| pretty_name(s));
-
+                if let Some(description) = &op.description {
+                    let comment = ctor.pydoc();
+                    comment.line(description.to_owned());
+                }
+                ctor.newline();
                 if let Some(cond) = &cond {
                     ctor.text(format!("self.{var_name} = "));
                     emit_resource_ir(context, &ctor, &op.value, Some(""));

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -10,19 +10,6 @@ import base64
   CloudFormation template, but does not attempt to represent a realistic stack.
 """
 class SimpleStack(Stack):
-  """
-    The ARN of the bucket in this template!
-  """
-  global bucket_arn
-  """
-    The ARN of the SQS Queue
-  """
-  global queue_arn
-  """
-    Whether this is a large region or not
-  """
-  global is_large
-
   def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
     super().__init__(scope, construct_id, **kwargs)
 
@@ -125,6 +112,9 @@ class SimpleStack(Stack):
       bucket.addDependency(queue)
 
     # Outputs
+    """
+      The ARN of the bucket in this template!
+    """
     self.bucket_arn = bucket.attr_arn if is_us_east1 else None
     if (is_us_east1):
       cdk.CfnOutput(self, 'BucketArn', 
@@ -133,15 +123,24 @@ class SimpleStack(Stack):
         value = self.bucket_arn,
       )
 
+
+    """
+      The ARN of the SQS Queue
+    """
     self.queue_arn = queue.ref
     cdk.CfnOutput(self, 'QueueArn', 
       description = 'The ARN of the SQS Queue',
       value = self.queue_arn,
     )
+
+    """
+      Whether this is a large region or not
+    """
     self.is_large = True if is_large_region else False
     cdk.CfnOutput(self, 'IsLarge', 
       description = 'Whether this is a large region or not',
       value = self.is_large,
     )
+
 
 


### PR DESCRIPTION
Currently python outputs were being both emitted as a class variable at the bottom of the class and as a global variable at the top of the class. I chose to emit them as globals to make it obvious what their purpose was and to pretend python has some consistency with other languages which require you declare your class variables before assigning their values in the constructor. This was not a pythonic way of doing this so I'm removing it and instead I'm just annotating the pydoc descriptions to the class variables themselves. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
