### PR TITLE
fix(python): props being improperly formatted

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -84,25 +84,25 @@ impl Synthesizer for Python {
                         indent: INDENT,
                         leading: Some(
                             format!(
-                                "'{name}': cdk.CfnParameter(self, '{}', {{",
+                                "'{name}': cdk.CfnParameter(self, '{}', ",
                                 camel_case(&param.name)
                             )
                             .into(),
                         ),
-                        trailing: Some("}),".into()),
+                        trailing: Some("),".into()),
                         trailing_newline: true,
                     });
-                    cfn_param.line(format!("'type': '{}',", param.constructor_type));
+                    cfn_param.line(format!("type = '{}',", param.constructor_type));
                     if let Some(v) = &param.default_value {
                         cfn_param.line(format!(
-                            "'default': str({name}) if {name} is not None else '{}',",
+                            "default = str(kwargs.get('{name}')) if kwargs.get('{name}') is not None else '{}',",
                             v.escape_debug()
                         ));
                     } else {
-                        cfn_param.line(format!("default: str({name}),"));
+                        cfn_param.line(format!("default = str(kwargs.get('{name}')),"));
                     };
                     if let Some(v) = &param.description {
-                        cfn_param.line(format!("description: '{}',", v));
+                        cfn_param.line(format!("description = '{}',", v));
                     };
                 } else {
                     let value = match &param.default_value {
@@ -126,7 +126,7 @@ impl Synthesizer for Python {
                     };
 
                     obj.line(format!(
-                        "'{name}': {name} if {name} is not None else {value},"
+                        "'{name}': kwargs.get('{name}') if kwargs.get('{name}') is not None else {value},"
                     ));
                 };
             }

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -15,11 +15,11 @@ class SimpleStack(Stack):
 
     # Applying default props
     props = {
-      'bucketNamePrefix': bucketNamePrefix if bucketNamePrefix is not None else 'bucket',
-      'logDestinationBucketName': cdk.CfnParameter(self, 'logDestinationBucketName', {
-        'type': 'AWS::SSM::Parameter::Value<String>',
-        'default': str(logDestinationBucketName) if logDestinationBucketName is not None else '/logging/bucket/name',
-      }),
+      'bucketNamePrefix': kwargs.get('bucketNamePrefix') if kwargs.get('bucketNamePrefix') is not None else 'bucket',
+      'logDestinationBucketName': cdk.CfnParameter(self, 'logDestinationBucketName', 
+        type = 'AWS::SSM::Parameter::Value<String>',
+        default = str(kwargs.get('logDestinationBucketName')) if kwargs.get('logDestinationBucketName') is not None else '/logging/bucket/name',
+      ),
     }
 
     # Mappings


### PR DESCRIPTION
Fixes Python props not being properly retrieved from kwargs, as well as a couple spots where we were using camel case instead of snake case



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
