### PR TITLE
fix(python): Python props were ugly and not very pythonic

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -78,6 +78,8 @@ impl Synthesizer for Python {
             .collect::<Vec<&ConstructorParameter>>();
         if !have_default_or_special_type_params.is_empty() {
             ctor.newline();
+            // props are handled weirdly in python. Python doesn't have interfaces so we try and retrieve
+            // the props from kwargs, and default to None or a default value if one is given.
             ctor.line("# Applying default props");
             let obj = ctor.indent_with_options(IndentOptions {
                 indent: INDENT,
@@ -103,7 +105,7 @@ impl Synthesizer for Python {
                     cfn_param.line(format!("type = '{}',", param.constructor_type));
                     if let Some(v) = &param.default_value {
                         cfn_param.line(format!(
-                            "default = str(kwargs.get('{name}')) if kwargs.get('{name}') is not None else '{}',",
+                            "default = str(kwargs.get('{name}'), '{}'),",
                             v.escape_debug()
                         ));
                     } else {
@@ -134,7 +136,7 @@ impl Synthesizer for Python {
                     };
 
                     obj.line(format!(
-                        "'{name}': kwargs.get('{name}') if kwargs.get('{name}') is not None else {value},"
+                        "'{name}': kwargs.get('{name}', {value}),"
                     ));
                 };
             }

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -135,9 +135,7 @@ impl Synthesizer for Python {
                         }
                     };
 
-                    obj.line(format!(
-                        "'{name}': kwargs.get('{name}', {value}),"
-                    ));
+                    obj.line(format!("'{name}': kwargs.get('{name}', {value}),"));
                 };
             }
         }

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -89,6 +89,7 @@ impl Synthesizer for Python {
             });
             for param in have_default_or_special_type_params {
                 let name = &param.name;
+                // example: AWS::EC2::Image::Id, List<AWS::EC2::VPC::Id>, AWS::SSM::Parameter::Value<List<String>>
                 if param.constructor_type.contains("AWS::") {
                     let cfn_param = obj.indent_with_options(IndentOptions {
                         indent: INDENT,

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -18,6 +18,8 @@ use super::Synthesizer;
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("  ");
 
+// reserved python keywords as of 3.13 (https://docs.python.org/3/reference/lexical_analysis.html#keywords)
+// if we happen to name a module with one of these keywords, we need to prepend 'aws_' to avoid a name conflict
 const KEYWORDS: &[&str] = &[
     "False", "await", "else", "import", "pass", "None", "break", "except", "in", "raise", "True",
     "class", "finally", "is", "return", "and", "continue", "for", "lambda", "try", "as", "def",
@@ -85,7 +87,6 @@ impl Synthesizer for Python {
             });
             for param in have_default_or_special_type_params {
                 let name = &param.name;
-                // example: AWS::EC2::Image::Id, List<AWS::EC2::VPC::Id>, AWS::SSM::Parameter::Value<List<String>>
                 if param.constructor_type.contains("AWS::") {
                     let cfn_param = obj.indent_with_options(IndentOptions {
                         indent: INDENT,

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -15,10 +15,10 @@ class SimpleStack(Stack):
 
     # Applying default props
     props = {
-      'bucketNamePrefix': kwargs.get('bucketNamePrefix') if kwargs.get('bucketNamePrefix') is not None else 'bucket',
+      'bucketNamePrefix': kwargs.get('bucketNamePrefix', 'bucket'),
       'logDestinationBucketName': cdk.CfnParameter(self, 'logDestinationBucketName', 
         type = 'AWS::SSM::Parameter::Value<String>',
-        default = str(kwargs.get('logDestinationBucketName')) if kwargs.get('logDestinationBucketName') is not None else '/logging/bucket/name',
+        default = str(kwargs.get('logDestinationBucketName'), '/logging/bucket/name'),
       ),
     }
 


### PR DESCRIPTION
I realized I didn't need a ternary operator to default these values and that the second positional argument of kwargs.get is a built in default value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
