### PR TITLE
fix(python): boolean exported values must be strings

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -87,6 +87,7 @@ impl Synthesizer for Python {
             });
             for param in have_default_or_special_type_params {
                 let name = &param.name;
+                // example: AWS::EC2::Image::Id, List<AWS::EC2::VPC::Id>, AWS::SSM::Parameter::Value<List<String>>
                 if param.constructor_type.contains("AWS::") {
                     let cfn_param = obj.indent_with_options(IndentOptions {
                         indent: INDENT,

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -224,7 +224,7 @@ fn emit_cfn_output(
         output.text("export_name = ");
         emit_resource_ir(context, &output, export, Some(",\n"));
     }
-    output.line(format!("value = self.{var_name},"));
+    output.line(format!("value = str(self.{var_name}),"));
 }
 
 impl ImportInstruction {

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -18,6 +18,8 @@ use super::Synthesizer;
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("  ");
 
+// reserved python keywords as of 3.13 (https://docs.python.org/3/reference/lexical_analysis.html#keywords)
+// if we happen to name a module with one of these keywords, we need to prepend 'aws_' to avoid a name conflict
 const KEYWORDS: &[&str] = &[
     "False", "await", "else", "import", "pass", "None", "break", "except", "in", "raise", "True",
     "class", "finally", "is", "return", "and", "continue", "for", "lambda", "try", "as", "def",
@@ -85,7 +87,6 @@ impl Synthesizer for Python {
             });
             for param in have_default_or_special_type_params {
                 let name = &param.name;
-                // example: AWS::EC2::Image::Id, List<AWS::EC2::VPC::Id>, AWS::SSM::Parameter::Value<List<String>>
                 if param.constructor_type.contains("AWS::") {
                     let cfn_param = obj.indent_with_options(IndentOptions {
                         indent: INDENT,

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -120,7 +120,7 @@ class SimpleStack(Stack):
       cdk.CfnOutput(self, 'BucketArn', 
         description = 'The ARN of the bucket in this template!',
         export_name = 'ExportName',
-        value = self.bucket_arn,
+        value = str(self.bucket_arn),
       )
 
 
@@ -130,7 +130,7 @@ class SimpleStack(Stack):
     self.queue_arn = queue.ref
     cdk.CfnOutput(self, 'QueueArn', 
       description = 'The ARN of the SQS Queue',
-      value = self.queue_arn,
+      value = str(self.queue_arn),
     )
 
     """
@@ -139,7 +139,7 @@ class SimpleStack(Stack):
     self.is_large = True if is_large_region else False
     cdk.CfnOutput(self, 'IsLarge', 
       description = 'Whether this is a large region or not',
-      value = self.is_large,
+      value = str(self.is_large),
     )
 
 


### PR DESCRIPTION
Fixes Exported values in python must be strings and nothing else. Casting exported value to string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
