### PR TITLE
fix(typescript): exported type mismatch

### DIFF
--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -362,7 +362,7 @@ fn emit_cfn_output(
     }
     output.text("exportName: ");
     emit_resource_ir(context, &output, export, Some(",\n"));
-    output.line(format!("value: this.{var_name}?.toString() ?? '',"));
+    output.line(format!("value: this.{var_name}!.toString(),"));
 }
 
 fn emit_resource(

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -362,7 +362,7 @@ fn emit_cfn_output(
     }
     output.text("exportName: ");
     emit_resource_ir(context, &output, export, Some(",\n"));
-    output.line(format!("value: this.{var_name},"));
+    output.line(format!("value: this.{var_name}?.toString() ?? '',"));
 }
 
 fn emit_resource(

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -147,7 +147,7 @@ export class SimpleStack extends cdk.Stack {
       new cdk.CfnOutput(this, 'BucketArn', {
         description: 'The ARN of the bucket in this template!',
         exportName: 'ExportName',
-        value: this.bucketArn,
+        value: this.bucketArn?.toString() ?? '',
       });
     }
     this.queueArn = queue.ref;

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -147,7 +147,7 @@ export class SimpleStack extends cdk.Stack {
       new cdk.CfnOutput(this, 'BucketArn', {
         description: 'The ARN of the bucket in this template!',
         exportName: 'ExportName',
-        value: this.bucketArn?.toString() ?? '',
+        value: this.bucketArn!.toString(),
       });
     }
     this.queueArn = queue.ref;


### PR DESCRIPTION
Fixes: exported value only expects a string but we would give it any type. Fixing this by casting it to a string

```
Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
