### PR TITLE
fix(python): booleans are not capitalized

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -12,7 +12,7 @@ use indexmap::IndexMap;
 use std::borrow::Cow;
 use std::io;
 use std::rc::Rc;
-use voca_rs::case::camel_case;
+use voca_rs::case::{camel_case, pascal_case};
 
 use super::Synthesizer;
 
@@ -130,6 +130,7 @@ impl Synthesizer for Python {
                                         .collect::<Vec<String>>()
                                         .join(",")
                                 ),
+                                "Boolean" => pascal_case(value),
                                 _ => value.clone(),
                             };
                             value


### PR DESCRIPTION
This change updates default values in boolean props to use Pascal Case.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
