### PR TITLE
fix(typescript): outputs only conditionally being created

### DIFF
--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -251,18 +251,16 @@ impl Synthesizer for Typescript {
                     emit_resource_ir(context, &ctor, &op.value, Some(";\n"));
                 }
 
-                if let Some(export) = &op.export {
-                    if let Some(cond) = cond {
-                        let indented = ctor.indent_with_options(IndentOptions {
-                            indent: INDENT,
-                            leading: Some(format!("if ({cond}) {{").into()),
-                            trailing: Some("}".into()),
-                            trailing_newline: true,
-                        });
-                        emit_cfn_output(context, &indented, op, export, &var_name);
-                    } else {
-                        emit_cfn_output(context, &ctor, op, export, &var_name);
-                    }
+                if let Some(cond) = cond {
+                    let indented = ctor.indent_with_options(IndentOptions {
+                        indent: INDENT,
+                        leading: Some(format!("if ({cond}) {{").into()),
+                        trailing: Some("}".into()),
+                        trailing_newline: true,
+                    });
+                    emit_cfn_output(context, &indented, op, &var_name);
+                } else {
+                    emit_cfn_output(context, &ctor, op, &var_name);
                 }
             }
         }
@@ -356,7 +354,6 @@ fn emit_cfn_output(
     context: &mut TypescriptContext,
     output: &CodeBuffer,
     op: &OutputInstruction,
-    export: &ResourceIr,
     var_name: &str,
 ) {
     let output = output.indent_with_options(IndentOptions {
@@ -369,8 +366,10 @@ fn emit_cfn_output(
     if let Some(description) = &op.description {
         output.line(format!("description: '{}',", description.escape_debug()));
     }
-    output.text("exportName: ");
-    emit_resource_ir(context, &output, export, Some(",\n"));
+    if let Some(export) = &op.export {
+        output.text("exportName: ");
+        emit_resource_ir(context, &output, export, Some(",\n"));
+    }
     output.line(format!("value: this.{var_name}!.toString(),"));
 }
 

--- a/tests/end-to-end/config/app.ts
+++ b/tests/end-to-end/config/app.ts
@@ -292,7 +292,16 @@ export class ConfigStack extends cdk.Stack {
 
     // Outputs
     this.configRuleForVolumeTagsArn = configRuleForVolumeTags.attrArn;
+    new cdk.CfnOutput(this, 'ConfigRuleForVolumeTagsArn', {
+      value: this.configRuleForVolumeTagsArn!.toString(),
+    });
     this.configRuleForVolumeTagsConfigRuleId = configRuleForVolumeTags.attrConfigRuleId;
+    new cdk.CfnOutput(this, 'ConfigRuleForVolumeTagsConfigRuleId', {
+      value: this.configRuleForVolumeTagsConfigRuleId!.toString(),
+    });
     this.configRuleForVolumeAutoEnableIoComplianceType = configRuleForVolumeAutoEnableIo.attrComplianceType;
+    new cdk.CfnOutput(this, 'ConfigRuleForVolumeAutoEnableIOComplianceType', {
+      value: this.configRuleForVolumeAutoEnableIoComplianceType!.toString(),
+    });
   }
 }

--- a/tests/end-to-end/documentdb/app.ts
+++ b/tests/end-to-end/documentdb/app.ts
@@ -64,8 +64,20 @@ export class DocumentDbStack extends cdk.Stack {
 
     // Outputs
     this.clusterId = dbCluster.ref;
+    new cdk.CfnOutput(this, 'ClusterId', {
+      value: this.clusterId!.toString(),
+    });
     this.clusterEndpoint = dbCluster.attrEndpoint;
+    new cdk.CfnOutput(this, 'ClusterEndpoint', {
+      value: this.clusterEndpoint!.toString(),
+    });
     this.clusterPort = dbCluster.attrPort;
+    new cdk.CfnOutput(this, 'ClusterPort', {
+      value: this.clusterPort!.toString(),
+    });
     this.engineVersion = '4.0.0';
+    new cdk.CfnOutput(this, 'EngineVersion', {
+      value: this.engineVersion!.toString(),
+    });
   }
 }

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -151,6 +151,14 @@ export class SimpleStack extends cdk.Stack {
       });
     }
     this.queueArn = queue.ref;
+    new cdk.CfnOutput(this, 'QueueArn', {
+      description: 'The ARN of the SQS Queue',
+      value: this.queueArn!.toString(),
+    });
     this.isLarge = isLargeRegion ? true : false;
+    new cdk.CfnOutput(this, 'IsLarge', {
+      description: 'Whether this is a large region or not',
+      value: this.isLarge!.toString(),
+    });
   }
 }


### PR DESCRIPTION
Fixes 

originally if a customer had an output but not an export we just weren't creating a cfn output. This changes that so we are always putting out an output, but the optionally adding an export if it was an export

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
