### PR TITLE
Fix a bug parsing files with ! operator

### DIFF
--- a/src/parser/resource/mod.rs
+++ b/src/parser/resource/mod.rs
@@ -52,7 +52,7 @@ impl<'de> serde::de::Deserialize<'de> for ResourceValue {
                 self,
                 data: A,
             ) -> Result<Self::Value, A::Error> {
-                IntrinsicFunction::from_enum(data).map(Into::into)
+                IntrinsicFunction::from_enum(data)
             }
 
             #[inline]


### PR DESCRIPTION
I have a Cfn template that uses `!` as a type specifier before strings that contain newlines. For example:
```
            /etc/cfn/cfn-hup.conf:
              content:
                Fn::Join:
                - ''
                - - ! '[main]

'
                  - stack=
                  - Ref: AWS::StackId
                  - ! '

'
                  - region=
                  - Ref: AWS::Region
                  - ! '

'
              group: root
              mode: '000444'
              owner: root
```

That leads to errors like these:
```
Error: Resources.ArtifactEncryptionKey.Properties.KeyPolicy.Statement[0].Principal.AWS.Fn::Join[1][0]: unknown variant `!`, expected one of `Base64`, `Cidr`, `FindInMap`, `GetAtt`, `GetAZs`, `If`, `ImportValue`, `Join`, `Select`, `Split`, `Sub`, `Ref` at line 205 column 19
```
This PR fixes those errors by changing the return type of `IntrinsicFunction::from_enum` so that it can wrap the next token instead of an IntrinsicFunction, and adding a match case for "!" that does so.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
