### PR TITLE
fix(typescript, python): iam policy keys are camel cased

### DIFF
--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -8,6 +8,7 @@ use crate::ir::reference::{Origin, PseudoParameter, Reference};
 use crate::ir::resources::{ResourceInstruction, ResourceIr};
 use crate::ir::CloudformationProgramIr;
 use crate::parser::lookup_table::MappingInnerValue;
+use crate::specification::Structure;
 use indexmap::IndexMap;
 use std::borrow::Cow;
 use std::io;
@@ -563,7 +564,7 @@ fn emit_resource_ir(
                 emit_resource_ir(context, &arr, item, Some(",\n"));
             }
         }
-        ResourceIr::Object(_, entries) => {
+        ResourceIr::Object(structure, entries) => {
             let obj = output.indent_with_options(IndentOptions {
                 indent: INDENT,
                 leading: Some("{".into()),
@@ -571,7 +572,14 @@ fn emit_resource_ir(
                 trailing_newline: false,
             });
             for (name, value) in entries {
-                obj.text(format!("'{key}': ", key = camel_case(name)));
+                match structure {
+                    Structure::Simple(_) => {
+                        obj.text(format!("'{name}': "));
+                    }
+                    _ => {
+                        obj.text(format!("'{key}': ", key = camel_case(name)));
+                    }
+                }
                 emit_resource_ir(context, &obj, value, Some(",\n"));
             }
         }

--- a/tests/end-to-end/config/app.py
+++ b/tests/end-to-end/config/app.py
@@ -42,16 +42,16 @@ class ConfigStack(Stack):
 
     lambdaExecutionRole = iam.CfnRole(self, 'LambdaExecutionRole',
           assume_role_policy_document = {
-            'version': '2012-10-17',
-            'statement': [
+            'Version': '2012-10-17',
+            'Statement': [
               {
-                'effect': 'Allow',
-                'principal': {
-                  'service': [
+                'Effect': 'Allow',
+                'Principal': {
+                  'Service': [
                     'lambda.amazonaws.com',
                   ],
                 },
-                'action': [
+                'Action': [
                   'sts:AssumeRole',
                 ],
               },
@@ -61,16 +61,16 @@ class ConfigStack(Stack):
             {
               'policyName': 'root',
               'policyDocument': {
-                'version': '2012-10-17',
-                'statement': [
+                'Version': '2012-10-17',
+                'Statement': [
                   {
-                    'effect': 'Allow',
-                    'action': [
+                    'Effect': 'Allow',
+                    'Action': [
                       'logs:*',
                       'config:PutEvaluations',
                       'ec2:DescribeVolumeAttribute',
                     ],
-                    'resource': '*',
+                    'Resource': '*',
                   },
                 ],
               },
@@ -80,16 +80,16 @@ class ConfigStack(Stack):
 
     configRole = iam.CfnRole(self, 'ConfigRole',
           assume_role_policy_document = {
-            'version': '2012-10-17',
-            'statement': [
+            'Version': '2012-10-17',
+            'Statement': [
               {
-                'effect': 'Allow',
-                'principal': {
-                  'service': [
+                'Effect': 'Allow',
+                'Principal': {
+                  'Service': [
                     'config.amazonaws.com',
                   ],
                 },
-                'action': [
+                'Action': [
                   'sts:AssumeRole',
                 ],
               },
@@ -102,36 +102,36 @@ class ConfigStack(Stack):
             {
               'policyName': 'root',
               'policyDocument': {
-                'version': '2012-10-17',
-                'statement': [
+                'Version': '2012-10-17',
+                'Statement': [
                   {
-                    'effect': 'Allow',
-                    'action': 's3:GetBucketAcl',
-                    'resource': ''.join([
+                    'Effect': 'Allow',
+                    'Action': 's3:GetBucketAcl',
+                    'Resource': ''.join([
                       'arn:aws:s3:::',
                       configBucket.ref,
                     ]),
                   },
                   {
-                    'effect': 'Allow',
-                    'action': 's3:PutObject',
-                    'resource': ''.join([
+                    'Effect': 'Allow',
+                    'Action': 's3:PutObject',
+                    'Resource': ''.join([
                       'arn:aws:s3:::',
                       configBucket.ref,
                       '/AWSLogs/',
                       self.account,
                       '/*',
                     ]),
-                    'condition': {
-                      'stringEquals': {
-                        's3XAmzAcl': 'bucket-owner-full-control',
+                    'Condition': {
+                      'StringEquals': {
+                        's3:x-amz-acl': 'bucket-owner-full-control',
                       },
                     },
                   },
                   {
-                    'effect': 'Allow',
-                    'action': 'config:Put*',
-                    'resource': '*',
+                    'Effect': 'Allow',
+                    'Action': 'config:Put*',
+                    'Resource': '*',
                   },
                 ],
               },
@@ -141,16 +141,16 @@ class ConfigStack(Stack):
 
     configTopicPolicy = sns.CfnTopicPolicy(self, 'ConfigTopicPolicy',
           policy_document = {
-            'id': 'ConfigTopicPolicy',
-            'version': '2012-10-17',
-            'statement': [
+            'Id': 'ConfigTopicPolicy',
+            'Version': '2012-10-17',
+            'Statement': [
               {
-                'effect': 'Allow',
-                'principal': {
-                  'service': 'config.amazonaws.com',
+                'Effect': 'Allow',
+                'Principal': {
+                  'Service': 'config.amazonaws.com',
                 },
-                'action': 'SNS:Publish',
-                'resource': '*',
+                'Action': 'SNS:Publish',
+                'Resource': '*',
               },
             ],
           },

--- a/tests/end-to-end/config/app.ts
+++ b/tests/end-to-end/config/app.ts
@@ -56,16 +56,16 @@ export class ConfigStack extends cdk.Stack {
 
     const lambdaExecutionRole = new iam.CfnRole(this, 'LambdaExecutionRole', {
       assumeRolePolicyDocument: {
-        version: '2012-10-17',
-        statement: [
+        Version: '2012-10-17',
+        Statement: [
           {
-            effect: 'Allow',
-            principal: {
-              service: [
+            Effect: 'Allow',
+            Principal: {
+              Service: [
                 'lambda.amazonaws.com',
               ],
             },
-            action: [
+            Action: [
               'sts:AssumeRole',
             ],
           },
@@ -75,16 +75,16 @@ export class ConfigStack extends cdk.Stack {
         {
           policyName: 'root',
           policyDocument: {
-            version: '2012-10-17',
-            statement: [
+            Version: '2012-10-17',
+            Statement: [
               {
-                effect: 'Allow',
-                action: [
+                Effect: 'Allow',
+                Action: [
                   'logs:*',
                   'config:PutEvaluations',
                   'ec2:DescribeVolumeAttribute',
                 ],
-                resource: '*',
+                Resource: '*',
               },
             ],
           },
@@ -95,16 +95,16 @@ export class ConfigStack extends cdk.Stack {
     if (configBucket == null) { throw new Error(`A combination of conditions caused 'configBucket' to be undefined. Fixit.`); }
     const configRole = new iam.CfnRole(this, 'ConfigRole', {
       assumeRolePolicyDocument: {
-        version: '2012-10-17',
-        statement: [
+        Version: '2012-10-17',
+        Statement: [
           {
-            effect: 'Allow',
-            principal: {
-              service: [
+            Effect: 'Allow',
+            Principal: {
+              Service: [
                 'config.amazonaws.com',
               ],
             },
-            action: [
+            Action: [
               'sts:AssumeRole',
             ],
           },
@@ -117,36 +117,36 @@ export class ConfigStack extends cdk.Stack {
         {
           policyName: 'root',
           policyDocument: {
-            version: '2012-10-17',
-            statement: [
+            Version: '2012-10-17',
+            Statement: [
               {
-                effect: 'Allow',
-                action: 's3:GetBucketAcl',
-                resource: [
+                Effect: 'Allow',
+                Action: 's3:GetBucketAcl',
+                Resource: [
                   'arn:aws:s3:::',
                   configBucket.ref,
                 ].join(''),
               },
               {
-                effect: 'Allow',
-                action: 's3:PutObject',
-                resource: [
+                Effect: 'Allow',
+                Action: 's3:PutObject',
+                Resource: [
                   'arn:aws:s3:::',
                   configBucket.ref,
                   '/AWSLogs/',
                   this.account,
                   '/*',
                 ].join(''),
-                condition: {
-                  stringEquals: {
-                    s3XAmzAcl: 'bucket-owner-full-control',
+                Condition: {
+                  StringEquals: {
+                    's3:x-amz-acl': 'bucket-owner-full-control',
                   },
                 },
               },
               {
-                effect: 'Allow',
-                action: 'config:Put*',
-                resource: '*',
+                Effect: 'Allow',
+                Action: 'config:Put*',
+                Resource: '*',
               },
             ],
           },
@@ -157,16 +157,16 @@ export class ConfigStack extends cdk.Stack {
     if (configTopic == null) { throw new Error(`A combination of conditions caused 'configTopic' to be undefined. Fixit.`); }
     const configTopicPolicy = new sns.CfnTopicPolicy(this, 'ConfigTopicPolicy', {
       policyDocument: {
-        id: 'ConfigTopicPolicy',
-        version: '2012-10-17',
-        statement: [
+        Id: 'ConfigTopicPolicy',
+        Version: '2012-10-17',
+        Statement: [
           {
-            effect: 'Allow',
-            principal: {
-              service: 'config.amazonaws.com',
+            Effect: 'Allow',
+            Principal: {
+              Service: 'config.amazonaws.com',
             },
-            action: 'SNS:Publish',
-            resource: '*',
+            Action: 'SNS:Publish',
+            Resource: '*',
           },
         ],
       },

--- a/tests/end-to-end/resource_w_json_type_properties/app.py
+++ b/tests/end-to-end/resource_w_json_type_properties/app.py
@@ -20,14 +20,14 @@ class JsonPropsStack(Stack):
             {
               'policyName': 'MyQueueGroupPolicy',
               'policyDocument': {
-                'statement': [
+                'Statement': [
                   {
-                    'effect': 'Allow',
-                    'action': [
+                    'Effect': 'Allow',
+                    'Action': [
                       'sqs:DeleteMessage',
                       'sqs:ReceiveMessage',
                     ],
-                    'resource': [
+                    'Resource': [
                       myQueue1.attr_arn,
                       myQueue2.attr_arn,
                     ],

--- a/tests/end-to-end/resource_w_json_type_properties/app.ts
+++ b/tests/end-to-end/resource_w_json_type_properties/app.ts
@@ -23,14 +23,14 @@ export class JsonPropsStack extends cdk.Stack {
         {
           policyName: 'MyQueueGroupPolicy',
           policyDocument: {
-            statement: [
+            Statement: [
               {
-                effect: 'Allow',
-                action: [
+                Effect: 'Allow',
+                Action: [
                   'sqs:DeleteMessage',
                   'sqs:ReceiveMessage',
                 ],
-                resource: [
+                Resource: [
                   myQueue1.attrArn,
                   myQueue2.attrArn,
                 ],


### PR DESCRIPTION
Neither typescript nor json were differentiating between simple and comoplex resource structures so they were incorrectly camelcasing all of the keys of a json string. This change leaves the keys as is when they are a simple structure, i.e., plain json.

Fixes #https://github.com/aws/aws-cdk/issues/28014

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
