### PR TITLE
fix(all): cfnOutput with the same key as construct causes collision in construct id

### DIFF
--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -638,7 +638,7 @@ impl OutputInstruction {
             indent: INDENT,
             leading: Some(
                 format!(
-                    "new CfnOutput(this, \"{}\", new CfnOutputProps {{",
+                    "new CfnOutput(this, \"CfnOutput{}\", new CfnOutputProps {{",
                     &self.name
                 )
                 .into(),
@@ -647,6 +647,7 @@ impl OutputInstruction {
             trailing_newline: true,
         });
 
+        output.line(format!("Key = \"{}\",", &self.name));
         if let Some(description) = &self.description {
             output.line(format!("Description = \"{}\",", description.escape_debug()));
         }

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -260,14 +260,15 @@ impl Synthesizer for Golang {
                     indent: INDENT,
                     leading: Some(
                         format!(
-                            "cdk.NewCfnOutput(stack, jsii.String({name:?}), &cdk.CfnOutputProps{{",
-                            name = output.name
+                            "cdk.NewCfnOutput(stack, jsii.String(\"CfnOutput{}\"), &cdk.CfnOutputProps{{",
+                            output.name
                         )
                         .into(),
                     ),
                     trailing: Some("})".into()),
                     trailing_newline: true,
                 });
+                props.line(format!("Key: jsii.String({name:?}),", name = output.name));
                 if let Some(description) = &output.description {
                     props.line(format!("Description: jsii.String({description:?}),"));
                 }

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -396,11 +396,16 @@ impl Java {
                     let output_writer = writer.indent_with_options(IndentOptions {
                         indent: DOUBLE_INDENT,
                         leading: Some(
-                            format!("CfnOutput.Builder.create(this, \"{}\")", &output.name).into(),
+                            format!(
+                                "CfnOutput.Builder.create(this, \"CfnOutput{}\")",
+                                &output.name
+                            )
+                            .into(),
                         ),
                         trailing: Some(format!("{DOUBLE_INDENT}.build();").into()),
                         trailing_newline: true,
                     });
+                    output_writer.line(format!(".key(\"{}\")", &output.name));
                     output_writer.line(format!(".value(this.{var_name}.toString())"));
                     output_writer
                 }
@@ -416,7 +421,7 @@ impl Java {
                         indent: DOUBLE_INDENT,
                         leading: Some(
                             format!(
-                                "this.{var_name}.ifPresent(_{var_name} -> CfnOutput.Builder.create(this, \"{}\")",
+                                "this.{var_name}.ifPresent(_{var_name} -> CfnOutput.Builder.create(this, \"CfnOutput{}\")",
                                 &output.name
                             )
                             .into(),
@@ -424,6 +429,7 @@ impl Java {
                         trailing: Some(format!("{DOUBLE_INDENT}.build());").into()),
                         trailing_newline: true,
                     });
+                    output_writer.line(format!(".key(\"{}\")", &output.name));
                     output_writer.line(format!(".value(_{var_name}.toString())"));
                     output_writer
                 }

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -215,11 +215,12 @@ fn emit_cfn_output(
 ) {
     let output = output.indent_with_options(IndentOptions {
         indent: INDENT,
-        leading: Some(format!("cdk.CfnOutput(self, '{}', ", &op.name).into()),
+        leading: Some(format!("cdk.CfnOutput(self, 'CfnOutput{}', ", &op.name).into()),
         trailing: Some(")".into()),
         trailing_newline: true,
     });
 
+    output.line(format!("key = '{}',", &op.name));
     if let Some(description) = &op.description {
         output.line(format!("description = '{}',", description.escape_debug()));
     }

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -360,11 +360,12 @@ fn emit_cfn_output(
 ) {
     let output = output.indent_with_options(IndentOptions {
         indent: INDENT,
-        leading: Some(format!("new cdk.CfnOutput(this, '{}', {{", &op.name).into()),
+        leading: Some(format!("new cdk.CfnOutput(this, 'CfnOutput{}', {{", &op.name).into()),
         trailing: Some("});".into()),
         trailing_newline: true,
     });
 
+    output.line(format!("key: '{}',", &op.name));
     if let Some(description) = &op.description {
         output.line(format!("description: '{}',", description.escape_debug()));
     }

--- a/tests/end-to-end/config/App.java
+++ b/tests/end-to-end/config/App.java
@@ -240,17 +240,20 @@ class ConfigStack extends Stack {
         configRuleForVolumeTags.addDependency(configRecorder);
 
         this.configRuleForVolumeTagsArn = configRuleForVolumeTags.getAttrArn();
-        CfnOutput.Builder.create(this, "ConfigRuleForVolumeTagsArn")
+        CfnOutput.Builder.create(this, "CfnOutputConfigRuleForVolumeTagsArn")
+                .key("ConfigRuleForVolumeTagsArn")
                 .value(this.configRuleForVolumeTagsArn.toString())
                 .build();
 
         this.configRuleForVolumeTagsConfigRuleId = configRuleForVolumeTags.getAttrConfigRuleId();
-        CfnOutput.Builder.create(this, "ConfigRuleForVolumeTagsConfigRuleId")
+        CfnOutput.Builder.create(this, "CfnOutputConfigRuleForVolumeTagsConfigRuleId")
+                .key("ConfigRuleForVolumeTagsConfigRuleId")
                 .value(this.configRuleForVolumeTagsConfigRuleId.toString())
                 .build();
 
         this.configRuleForVolumeAutoEnableIoComplianceType = configRuleForVolumeAutoEnableIo.getAttrComplianceType();
-        CfnOutput.Builder.create(this, "ConfigRuleForVolumeAutoEnableIOComplianceType")
+        CfnOutput.Builder.create(this, "CfnOutputConfigRuleForVolumeAutoEnableIOComplianceType")
+                .key("ConfigRuleForVolumeAutoEnableIOComplianceType")
                 .value(this.configRuleForVolumeAutoEnableIoComplianceType.toString())
                 .build();
 

--- a/tests/end-to-end/config/app.py
+++ b/tests/end-to-end/config/app.py
@@ -266,17 +266,20 @@ class ConfigStack(Stack):
 
     # Outputs
     self.config_rule_for_volume_tags_arn = configRuleForVolumeTags.attr_arn
-    cdk.CfnOutput(self, 'ConfigRuleForVolumeTagsArn', 
+    cdk.CfnOutput(self, 'CfnOutputConfigRuleForVolumeTagsArn', 
+      key = 'ConfigRuleForVolumeTagsArn',
       value = str(self.config_rule_for_volume_tags_arn),
     )
 
     self.config_rule_for_volume_tags_config_rule_id = configRuleForVolumeTags.attr_config_rule_id
-    cdk.CfnOutput(self, 'ConfigRuleForVolumeTagsConfigRuleId', 
+    cdk.CfnOutput(self, 'CfnOutputConfigRuleForVolumeTagsConfigRuleId', 
+      key = 'ConfigRuleForVolumeTagsConfigRuleId',
       value = str(self.config_rule_for_volume_tags_config_rule_id),
     )
 
     self.config_rule_for_volume_auto_enable_io_compliance_type = configRuleForVolumeAutoEnableIo.attr_compliance_type
-    cdk.CfnOutput(self, 'ConfigRuleForVolumeAutoEnableIOComplianceType', 
+    cdk.CfnOutput(self, 'CfnOutputConfigRuleForVolumeAutoEnableIOComplianceType', 
+      key = 'ConfigRuleForVolumeAutoEnableIOComplianceType',
       value = str(self.config_rule_for_volume_auto_enable_io_compliance_type),
     )
 

--- a/tests/end-to-end/config/app.ts
+++ b/tests/end-to-end/config/app.ts
@@ -292,15 +292,18 @@ export class ConfigStack extends cdk.Stack {
 
     // Outputs
     this.configRuleForVolumeTagsArn = configRuleForVolumeTags.attrArn;
-    new cdk.CfnOutput(this, 'ConfigRuleForVolumeTagsArn', {
+    new cdk.CfnOutput(this, 'CfnOutputConfigRuleForVolumeTagsArn', {
+      key: 'ConfigRuleForVolumeTagsArn',
       value: this.configRuleForVolumeTagsArn!.toString(),
     });
     this.configRuleForVolumeTagsConfigRuleId = configRuleForVolumeTags.attrConfigRuleId;
-    new cdk.CfnOutput(this, 'ConfigRuleForVolumeTagsConfigRuleId', {
+    new cdk.CfnOutput(this, 'CfnOutputConfigRuleForVolumeTagsConfigRuleId', {
+      key: 'ConfigRuleForVolumeTagsConfigRuleId',
       value: this.configRuleForVolumeTagsConfigRuleId!.toString(),
     });
     this.configRuleForVolumeAutoEnableIoComplianceType = configRuleForVolumeAutoEnableIo.attrComplianceType;
-    new cdk.CfnOutput(this, 'ConfigRuleForVolumeAutoEnableIOComplianceType', {
+    new cdk.CfnOutput(this, 'CfnOutputConfigRuleForVolumeAutoEnableIOComplianceType', {
+      key: 'ConfigRuleForVolumeAutoEnableIOComplianceType',
       value: this.configRuleForVolumeAutoEnableIoComplianceType!.toString(),
     });
   }

--- a/tests/end-to-end/documentdb/App.java
+++ b/tests/end-to-end/documentdb/App.java
@@ -78,22 +78,26 @@ class DocumentDbStack extends Stack {
         dbInstance.addDependency(dbCluster);
 
         this.clusterId = dbCluster.getRef();
-        CfnOutput.Builder.create(this, "ClusterId")
+        CfnOutput.Builder.create(this, "CfnOutputClusterId")
+                .key("ClusterId")
                 .value(this.clusterId.toString())
                 .build();
 
         this.clusterEndpoint = dbCluster.getAttrEndpoint();
-        CfnOutput.Builder.create(this, "ClusterEndpoint")
+        CfnOutput.Builder.create(this, "CfnOutputClusterEndpoint")
+                .key("ClusterEndpoint")
                 .value(this.clusterEndpoint.toString())
                 .build();
 
         this.clusterPort = dbCluster.getAttrPort();
-        CfnOutput.Builder.create(this, "ClusterPort")
+        CfnOutput.Builder.create(this, "CfnOutputClusterPort")
+                .key("ClusterPort")
                 .value(this.clusterPort.toString())
                 .build();
 
         this.engineVersion = "4.0.0";
-        CfnOutput.Builder.create(this, "EngineVersion")
+        CfnOutput.Builder.create(this, "CfnOutputEngineVersion")
+                .key("EngineVersion")
                 .value(this.engineVersion.toString())
                 .build();
 

--- a/tests/end-to-end/documentdb/app.py
+++ b/tests/end-to-end/documentdb/app.py
@@ -34,22 +34,26 @@ class DocumentDbStack(Stack):
 
     # Outputs
     self.cluster_id = dbCluster.ref
-    cdk.CfnOutput(self, 'ClusterId', 
+    cdk.CfnOutput(self, 'CfnOutputClusterId', 
+      key = 'ClusterId',
       value = str(self.cluster_id),
     )
 
     self.cluster_endpoint = dbCluster.attr_endpoint
-    cdk.CfnOutput(self, 'ClusterEndpoint', 
+    cdk.CfnOutput(self, 'CfnOutputClusterEndpoint', 
+      key = 'ClusterEndpoint',
       value = str(self.cluster_endpoint),
     )
 
     self.cluster_port = dbCluster.attr_port
-    cdk.CfnOutput(self, 'ClusterPort', 
+    cdk.CfnOutput(self, 'CfnOutputClusterPort', 
+      key = 'ClusterPort',
       value = str(self.cluster_port),
     )
 
     self.engine_version = '4.0.0'
-    cdk.CfnOutput(self, 'EngineVersion', 
+    cdk.CfnOutput(self, 'CfnOutputEngineVersion', 
+      key = 'EngineVersion',
       value = str(self.engine_version),
     )
 

--- a/tests/end-to-end/documentdb/app.ts
+++ b/tests/end-to-end/documentdb/app.ts
@@ -64,19 +64,23 @@ export class DocumentDbStack extends cdk.Stack {
 
     // Outputs
     this.clusterId = dbCluster.ref;
-    new cdk.CfnOutput(this, 'ClusterId', {
+    new cdk.CfnOutput(this, 'CfnOutputClusterId', {
+      key: 'ClusterId',
       value: this.clusterId!.toString(),
     });
     this.clusterEndpoint = dbCluster.attrEndpoint;
-    new cdk.CfnOutput(this, 'ClusterEndpoint', {
+    new cdk.CfnOutput(this, 'CfnOutputClusterEndpoint', {
+      key: 'ClusterEndpoint',
       value: this.clusterEndpoint!.toString(),
     });
     this.clusterPort = dbCluster.attrPort;
-    new cdk.CfnOutput(this, 'ClusterPort', {
+    new cdk.CfnOutput(this, 'CfnOutputClusterPort', {
+      key: 'ClusterPort',
       value: this.clusterPort!.toString(),
     });
     this.engineVersion = '4.0.0';
-    new cdk.CfnOutput(this, 'EngineVersion', {
+    new cdk.CfnOutput(this, 'CfnOutputEngineVersion', {
+      key: 'EngineVersion',
       value: this.engineVersion!.toString(),
     });
   }

--- a/tests/end-to-end/simple/App.cs
+++ b/tests/end-to-end/simple/App.cs
@@ -125,7 +125,8 @@ namespace SimpleStack
                 ? bucket.AttrArn
                 : null;
             if (isUsEast1) {
-                new CfnOutput(this, "BucketArn", new CfnOutputProps {
+                new CfnOutput(this, "CfnOutputBucketArn", new CfnOutputProps {
+                    Key = "BucketArn",
                     Description = "The ARN of the bucket in this template!",
                     ExportName = "ExportName",
                     Value = BucketArn as string,

--- a/tests/end-to-end/simple/App.java
+++ b/tests/end-to-end/simple/App.java
@@ -125,21 +125,24 @@ class SimpleStack extends Stack {
 
         this.bucketArn = isUsEast1 ? Optional.of(bucket.isPresent() ? bucket.get().getAttrArn()
                 : Optional.empty()) : Optional.empty();
-        this.bucketArn.ifPresent(_bucketArn -> CfnOutput.Builder.create(this, "BucketArn")
+        this.bucketArn.ifPresent(_bucketArn -> CfnOutput.Builder.create(this, "CfnOutputBucketArn")
+                .key("BucketArn")
                 .value(_bucketArn.toString())
                 .description("The ARN of the bucket in this template!")
                 .exportName("ExportName")
                 .build());
 
         this.queueArn = queue.getRef();
-        CfnOutput.Builder.create(this, "QueueArn")
+        CfnOutput.Builder.create(this, "CfnOutputQueueArn")
+                .key("QueueArn")
                 .value(this.queueArn.toString())
                 .description("The ARN of the SQS Queue")
                 .build();
 
         this.isLarge = isLargeRegion ? true
                 : false;
-        CfnOutput.Builder.create(this, "IsLarge")
+        CfnOutput.Builder.create(this, "CfnOutputIsLarge")
+                .key("IsLarge")
                 .value(this.isLarge.toString())
                 .description("Whether this is a large region or not")
                 .build();

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -146,7 +146,8 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 		},
 	)
 
-	cdk.NewCfnOutput(stack, jsii.String("BucketArn"), &cdk.CfnOutputProps{
+	cdk.NewCfnOutput(stack, jsii.String("CfnOutputBucketArn"), &cdk.CfnOutputProps{
+		Key: jsii.String("BucketArn"),
 		Description: jsii.String("The ARN of the bucket in this template!"),
 		ExportName: jsii.String("ExportName"),
 		Value: bucket.AttrArn(),

--- a/tests/end-to-end/simple/app.py
+++ b/tests/end-to-end/simple/app.py
@@ -117,7 +117,8 @@ class SimpleStack(Stack):
     """
     self.bucket_arn = bucket.attr_arn if is_us_east1 else None
     if (is_us_east1):
-      cdk.CfnOutput(self, 'BucketArn', 
+      cdk.CfnOutput(self, 'CfnOutputBucketArn', 
+        key = 'BucketArn',
         description = 'The ARN of the bucket in this template!',
         export_name = 'ExportName',
         value = str(self.bucket_arn),
@@ -128,7 +129,8 @@ class SimpleStack(Stack):
       The ARN of the SQS Queue
     """
     self.queue_arn = queue.ref
-    cdk.CfnOutput(self, 'QueueArn', 
+    cdk.CfnOutput(self, 'CfnOutputQueueArn', 
+      key = 'QueueArn',
       description = 'The ARN of the SQS Queue',
       value = str(self.queue_arn),
     )
@@ -137,7 +139,8 @@ class SimpleStack(Stack):
       Whether this is a large region or not
     """
     self.is_large = True if is_large_region else False
-    cdk.CfnOutput(self, 'IsLarge', 
+    cdk.CfnOutput(self, 'CfnOutputIsLarge', 
+      key = 'IsLarge',
       description = 'Whether this is a large region or not',
       value = str(self.is_large),
     )

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -144,19 +144,22 @@ export class SimpleStack extends cdk.Stack {
       ? bucket?.attrArn
       : undefined;
     if (isUsEast1) {
-      new cdk.CfnOutput(this, 'BucketArn', {
+      new cdk.CfnOutput(this, 'CfnOutputBucketArn', {
+        key: 'BucketArn',
         description: 'The ARN of the bucket in this template!',
         exportName: 'ExportName',
         value: this.bucketArn!.toString(),
       });
     }
     this.queueArn = queue.ref;
-    new cdk.CfnOutput(this, 'QueueArn', {
+    new cdk.CfnOutput(this, 'CfnOutputQueueArn', {
+      key: 'QueueArn',
       description: 'The ARN of the SQS Queue',
       value: this.queueArn!.toString(),
     });
     this.isLarge = isLargeRegion ? true : false;
-    new cdk.CfnOutput(this, 'IsLarge', {
+    new cdk.CfnOutput(this, 'CfnOutputIsLarge', {
+      key: 'IsLarge',
       description: 'Whether this is a large region or not',
       value: this.isLarge!.toString(),
     });


### PR DESCRIPTION
This change adds the prefix 'CfnOutput' to each of the output construct IDs and then adds the key field to set the correct key.

Fixes https://github.com/cdklabs/cdk-from-cfn/issues/404

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
