### PR TITLE
fix(csharp): if user does not supply props to stack constructor, they remain null and cause a C# runtime error

### DIFF
--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -118,6 +118,7 @@ impl Synthesizer for CSharp {
             .collect::<Vec<&ConstructorParameter>>();
         if !have_default_or_special_type_params.is_empty() {
             ctor.line("// Applying default props");
+            ctor.line("props ??= new SimpleStackProps();");
             for param in have_default_or_special_type_params {
                 let name = pascal_case(&param.name);
                 // example: AWS::EC2::Image::Id, List<AWS::EC2::VPC::Id>, AWS::SSM::Parameter::Value<List<String>>

--- a/tests/end-to-end/config/App.cs
+++ b/tests/end-to-end/config/App.cs
@@ -32,6 +32,7 @@ namespace ConfigStack
         public ConfigStack(Construct scope, string id, ConfigStackProps props = null) : base(scope, id, props)
         {
             // Applying default props
+            props ??= new SimpleStackProps();
             props.Ec2VolumeAutoEnableIo ??= false;
             props.Ec2VolumeTagKey ??= "CostCenter";
 

--- a/tests/end-to-end/documentdb/App.cs
+++ b/tests/end-to-end/documentdb/App.cs
@@ -50,6 +50,7 @@ namespace DocumentDbStack
         public DocumentDbStack(Construct scope, string id, DocumentDbStackProps props = null) : base(scope, id, props)
         {
             // Applying default props
+            props ??= new SimpleStackProps();
             props.DbClusterName ??= "MyCluster";
             props.DbInstanceName ??= "MyInstance";
 

--- a/tests/end-to-end/simple/App.cs
+++ b/tests/end-to-end/simple/App.cs
@@ -41,6 +41,7 @@ namespace SimpleStack
         public SimpleStack(Construct scope, string id, SimpleStackProps props = null) : base(scope, id, props)
         {
             // Applying default props
+            props ??= new SimpleStackProps();
             props.BucketNamePrefix ??= "bucket";
             props.LogDestinationBucketName = new CfnParameter(this, "LogDestinationBucketName", new CfnParameterProps
             {


### PR DESCRIPTION
In this case, set props to default constructor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
