### PR TITLE
fix(go): cdk-from-cfn does not produce working go files

### DIFF
--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -47,7 +47,7 @@ impl Synthesizer for Golang {
     ) -> io::Result<()> {
         let code = CodeBuffer::default();
 
-        code.line(format!("package {}", self.package_name));
+        code.line("package main");
         code.newline();
 
         let imports = code.indent_with_options(IndentOptions {
@@ -107,7 +107,7 @@ impl Synthesizer for Golang {
             indent: INDENT,
             leading: Some(
                 format!(
-                    "func New{}(scope constructs.Construct, id string, props {}Props) *{} {{",
+                    "func New{}(scope constructs.Construct, id string, props *{}Props) *{} {{",
                     stack_name, stack_name, stack_name
                 )
                 .into(),
@@ -196,8 +196,15 @@ impl Synthesizer for Golang {
             }
             ctor.newline();
         }
-
-        ctor.line("stack := cdk.NewStack(scope, &id, &props.StackProps)");
+        ctor.line("var sprops cdk.StackProps");
+        let props_nil_block = ctor.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some("if props != nil {".into()),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
+        props_nil_block.line("sprops = props.StackProps");
+        ctor.line("stack := cdk.NewStack(scope, &id, &sprops)");
         ctor.newline();
 
         for condition in &ir.conditions {

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -197,13 +197,13 @@ impl Synthesizer for Golang {
             ctor.newline();
         }
         ctor.line("var sprops cdk.StackProps");
-        let props_nil_block = ctor.indent_with_options(IndentOptions {
+        let props_not_nil_block = ctor.indent_with_options(IndentOptions {
             indent: INDENT,
             leading: Some("if props != nil {".into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
-        props_nil_block.line("sprops = props.StackProps");
+        props_not_nil_block.line("sprops = props.StackProps");
         ctor.line("stack := cdk.NewStack(scope, &id, &sprops)");
         ctor.newline();
 

--- a/tests/end-to-end/config/app.go
+++ b/tests/end-to-end/config/app.go
@@ -1,4 +1,4 @@
-package config
+package main
 
 import (
 	cdk "github.com/aws/aws-cdk-go/awscdk/v2"
@@ -26,8 +26,12 @@ type ConfigStack struct {
 	ConfigRuleForVolumeAutoEnableIoComplianceType interface{} // TODO: fix to appropriate type
 }
 
-func NewConfigStack(scope constructs.Construct, id string, props ConfigStackProps) *ConfigStack {
-	stack := cdk.NewStack(scope, &id, &props.StackProps)
+func NewConfigStack(scope constructs.Construct, id string, props *ConfigStackProps) *ConfigStack {
+	var sprops cdk.StackProps
+	if props != nil {
+		sprops = props.StackProps
+	}
+	stack := cdk.NewStack(scope, &id, &sprops)
 
 	configBucket := s3.NewCfnBucket(
 		stack,

--- a/tests/end-to-end/documentdb/app.go
+++ b/tests/end-to-end/documentdb/app.go
@@ -1,4 +1,4 @@
-package documentdb
+package main
 
 import (
 	cdk "github.com/aws/aws-cdk-go/awscdk/v2"
@@ -30,8 +30,12 @@ type DocumentDbStack struct {
 	EngineVersion interface{} // TODO: fix to appropriate type
 }
 
-func NewDocumentDbStack(scope constructs.Construct, id string, props DocumentDbStackProps) *DocumentDbStack {
-	stack := cdk.NewStack(scope, &id, &props.StackProps)
+func NewDocumentDbStack(scope constructs.Construct, id string, props *DocumentDbStackProps) *DocumentDbStack {
+	var sprops cdk.StackProps
+	if props != nil {
+		sprops = props.StackProps
+	}
+	stack := cdk.NewStack(scope, &id, &sprops)
 
 	dbCluster := doc_db.NewCfnDBCluster(
 		stack,

--- a/tests/end-to-end/resource_w_json_type_properties/app.go
+++ b/tests/end-to-end/resource_w_json_type_properties/app.go
@@ -1,4 +1,4 @@
-package resource_w_json_type_properties
+package main
 
 import (
 	cdk "github.com/aws/aws-cdk-go/awscdk/v2"
@@ -16,8 +16,12 @@ type JsonPropsStack struct {
 	cdk.Stack
 }
 
-func NewJsonPropsStack(scope constructs.Construct, id string, props JsonPropsStackProps) *JsonPropsStack {
-	stack := cdk.NewStack(scope, &id, &props.StackProps)
+func NewJsonPropsStack(scope constructs.Construct, id string, props *JsonPropsStackProps) *JsonPropsStack {
+	var sprops cdk.StackProps
+	if props != nil {
+		sprops = props.StackProps
+	}
+	stack := cdk.NewStack(scope, &id, &sprops)
 
 	myQueue1 := sqs.NewCfnQueue(
 		stack,

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -1,4 +1,4 @@
-package simple
+package main
 
 import (
 	"fmt"
@@ -29,7 +29,7 @@ type SimpleStack struct {
 	IsLarge interface{} // TODO: fix to appropriate type
 }
 
-func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProps) *SimpleStack {
+func NewSimpleStack(scope constructs.Construct, id string, props *SimpleStackProps) *SimpleStack {
 	/*
 	booleans := map[*string]map[*string]*bool{
 		jsii.String("True"): map[*string]*bool{
@@ -91,7 +91,11 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 		},
 	}
 
-	stack := cdk.NewStack(scope, &id, &props.StackProps)
+	var sprops cdk.StackProps
+	if props != nil {
+		sprops = props.StackProps
+	}
+	stack := cdk.NewStack(scope, &id, &sprops)
 
 	isUs := cdk.Fn_Select(jsii.Number(0), cdk.Fn_Split(jsii.String("-"), stack.Region())) == jsii.String("us")
 

--- a/tests/end-to-end/vpc/app.go
+++ b/tests/end-to-end/vpc/app.go
@@ -1,4 +1,4 @@
-package vpc
+package main
 
 import (
 	cdk "github.com/aws/aws-cdk-go/awscdk/v2"
@@ -15,8 +15,12 @@ type VpcStack struct {
 	cdk.Stack
 }
 
-func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *VpcStack {
-	stack := cdk.NewStack(scope, &id, &props.StackProps)
+func NewVpcStack(scope constructs.Construct, id string, props *VpcStackProps) *VpcStack {
+	var sprops cdk.StackProps
+	if props != nil {
+		sprops = props.StackProps
+	}
+	stack := cdk.NewStack(scope, &id, &sprops)
 
 	vpc := ec2.NewCfnVPC(
 		stack,


### PR DESCRIPTION
This fixes 3 issues in order to allow the most basic of go stacks to work. It does not fix all current issues with go, so the title might be a bit too broad. If anyone has suggestions for a better title here, I'd love to here it.


| | Issue  | Fix |
|-| ------------- | ------------- |
|1| A file produced by cdk-from-cfn cannot be used as the main executable in a CDK app because it declares a `main` function in a package that is not called main.  | change the package name line to `package main`. See https://go.dev/doc/modules/layout |
|2| The props parameter of the Stack constructor is not a pointer, which prevents it from being able to be optional. | Make props a pointer.  |
|3| If `nil` is supplied as the prop argument of the Stack constructor, a runtime error occurs because we cannot dereference `nil` to get the `StackProps` to pass to the Stack base class constructor    | Handle nil case, and create default `StackProps`                        |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
