### PR TITLE
chore(typescript): remove troubleshooting lines

### DIFF
--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -385,8 +385,6 @@ fn emit_resource(
     let service = reference.resource_type.service().to_lowercase();
 
     let maybe_undefined = if let Some(cond) = &reference.condition {
-        append_references(output, reference);
-
         output.line(format!(
             "const {var_name} = {cond}",
             cond = pretty_name(cond)
@@ -408,7 +406,6 @@ fn emit_resource(
 
         true
     } else {
-        append_references(output, reference);
         output.line(format!(
             "const {var_name} = new {service}.Cfn{rtype}(this, '{}', {{",
             reference.name.escape_debug(),
@@ -761,13 +758,6 @@ fn emit_mapping_instruction(output: Rc<CodeBuffer>, mapping_instruction: &Mappin
 fn emit_inner_mapping(output: Rc<CodeBuffer>, inner_mapping: &IndexMap<String, MappingInnerValue>) {
     for (name, value) in inner_mapping {
         output.line(format!("'{key}': {value},", key = name.escape_debug()));
-    }
-}
-
-fn append_references(output: &CodeBuffer, reference: &ResourceInstruction) {
-    // Need something that doesn't allow repeats or just don't add the repeats
-    for dep in &reference.references {
-        output.line(format!("if ({dep} == null) {{ throw new Error(`A combination of conditions caused '{dep}' to be undefined. Fixit.`); }}", dep=pretty_name(dep)));
     }
 }
 

--- a/tests/end-to-end/config/app.ts
+++ b/tests/end-to-end/config/app.ts
@@ -92,7 +92,6 @@ export class ConfigStack extends cdk.Stack {
       ],
     });
 
-    if (configBucket == null) { throw new Error(`A combination of conditions caused 'configBucket' to be undefined. Fixit.`); }
     const configRole = new iam.CfnRole(this, 'ConfigRole', {
       assumeRolePolicyDocument: {
         Version: '2012-10-17',
@@ -154,7 +153,6 @@ export class ConfigStack extends cdk.Stack {
       ],
     });
 
-    if (configTopic == null) { throw new Error(`A combination of conditions caused 'configTopic' to be undefined. Fixit.`); }
     const configTopicPolicy = new sns.CfnTopicPolicy(this, 'ConfigTopicPolicy', {
       policyDocument: {
         Id: 'ConfigTopicPolicy',
@@ -175,8 +173,6 @@ export class ConfigStack extends cdk.Stack {
       ],
     });
 
-    if (configBucket == null) { throw new Error(`A combination of conditions caused 'configBucket' to be undefined. Fixit.`); }
-    if (configTopic == null) { throw new Error(`A combination of conditions caused 'configTopic' to be undefined. Fixit.`); }
     const deliveryChannel = new config.CfnDeliveryChannel(this, 'DeliveryChannel', {
       configSnapshotDeliveryProperties: {
         deliveryFrequency: 'Six_Hours',
@@ -185,7 +181,6 @@ export class ConfigStack extends cdk.Stack {
       snsTopicArn: configTopic.ref,
     });
 
-    if (lambdaExecutionRole == null) { throw new Error(`A combination of conditions caused 'lambdaExecutionRole' to be undefined. Fixit.`); }
     const volumeAutoEnableIoComplianceCheck = new lambda.CfnFunction(this, 'VolumeAutoEnableIOComplianceCheck', {
       code: {
         zipFile: [
@@ -229,14 +224,12 @@ export class ConfigStack extends cdk.Stack {
       role: lambdaExecutionRole.attrArn,
     });
 
-    if (volumeAutoEnableIoComplianceCheck == null) { throw new Error(`A combination of conditions caused 'volumeAutoEnableIoComplianceCheck' to be undefined. Fixit.`); }
     const configPermissionToCallLambda = new lambda.CfnPermission(this, 'ConfigPermissionToCallLambda', {
       functionName: volumeAutoEnableIoComplianceCheck.attrArn,
       action: 'lambda:InvokeFunction',
       principal: 'config.amazonaws.com',
     });
 
-    if (configRole == null) { throw new Error(`A combination of conditions caused 'configRole' to be undefined. Fixit.`); }
     const configRecorder = new config.CfnConfigurationRecorder(this, 'ConfigRecorder', {
       name: 'default',
       recordingGroup: {
@@ -247,10 +240,6 @@ export class ConfigStack extends cdk.Stack {
       roleArn: configRole.attrArn,
     });
 
-    if (configPermissionToCallLambda == null) { throw new Error(`A combination of conditions caused 'configPermissionToCallLambda' to be undefined. Fixit.`); }
-    if (configRecorder == null) { throw new Error(`A combination of conditions caused 'configRecorder' to be undefined. Fixit.`); }
-    if (ec2Volume == null) { throw new Error(`A combination of conditions caused 'ec2Volume' to be undefined. Fixit.`); }
-    if (volumeAutoEnableIoComplianceCheck == null) { throw new Error(`A combination of conditions caused 'volumeAutoEnableIoComplianceCheck' to be undefined. Fixit.`); }
     const configRuleForVolumeAutoEnableIo = new config.CfnConfigRule(this, 'ConfigRuleForVolumeAutoEnableIO', {
       configRuleName: 'ConfigRuleForVolumeAutoEnableIO',
       scope: {
@@ -273,7 +262,6 @@ export class ConfigStack extends cdk.Stack {
     configRuleForVolumeAutoEnableIo.addDependency(configPermissionToCallLambda);
     configRuleForVolumeAutoEnableIo.addDependency(configRecorder);
 
-    if (configRecorder == null) { throw new Error(`A combination of conditions caused 'configRecorder' to be undefined. Fixit.`); }
     const configRuleForVolumeTags = new config.CfnConfigRule(this, 'ConfigRuleForVolumeTags', {
       inputParameters: {
         tag1Key: 'CostCenter',

--- a/tests/end-to-end/documentdb/app.ts
+++ b/tests/end-to-end/documentdb/app.ts
@@ -54,7 +54,6 @@ export class DocumentDbStack extends cdk.Stack {
     });
     dbCluster.cfnOptions.deletionPolicy = cdk.CfnDeletionPolicy.DELETE;
 
-    if (dbCluster == null) { throw new Error(`A combination of conditions caused 'dbCluster' to be undefined. Fixit.`); }
     const dbInstance = new docdb.CfnDBInstance(this, 'DBInstance', {
       dbClusterIdentifier: dbCluster.ref,
       dbInstanceIdentifier: props.dbInstanceName!,

--- a/tests/end-to-end/resource_w_json_type_properties/app.ts
+++ b/tests/end-to-end/resource_w_json_type_properties/app.ts
@@ -16,8 +16,6 @@ export class JsonPropsStack extends cdk.Stack {
     const myQueue2 = new sqs.CfnQueue(this, 'MyQueue2', {
     });
 
-    if (myQueue1 == null) { throw new Error(`A combination of conditions caused 'myQueue1' to be undefined. Fixit.`); }
-    if (myQueue2 == null) { throw new Error(`A combination of conditions caused 'myQueue2' to be undefined. Fixit.`); }
     const myRdMessageQueueGroup = new iam.CfnGroup(this, 'MyRDMessageQueueGroup', {
       policies: [
         {

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -107,7 +107,6 @@ export class SimpleStack extends cdk.Stack {
       visibilityTimeout: 120,
     });
 
-    if (queue == null) { throw new Error(`A combination of conditions caused 'queue' to be undefined. Fixit.`); }
     const bucket = isUsEast1
       ? new s3.CfnBucket(this, 'Bucket', {
           accessControl: 'private',

--- a/tests/end-to-end/vpc/app.ts
+++ b/tests/end-to-end/vpc/app.ts
@@ -21,21 +21,18 @@ export class VpcStack extends cdk.Stack {
       ],
     });
 
-    if (vpc == null) { throw new Error(`A combination of conditions caused 'vpc' to be undefined. Fixit.`); }
     const subnet1 = new ec2.CfnSubnet(this, 'Subnet1', {
       availabilityZone: cdk.Fn.select(0, cdk.Fn.getAzs('')),
       cidrBlock: cdk.Fn.select(0, cdk.Fn.cidr(vpc.attrCidrBlock, 6, String(8))),
       vpcId: vpc.ref,
     });
 
-    if (vpc == null) { throw new Error(`A combination of conditions caused 'vpc' to be undefined. Fixit.`); }
     const subnet2 = new ec2.CfnSubnet(this, 'Subnet2', {
       availabilityZone: cdk.Fn.select(1, cdk.Fn.getAzs('')),
       cidrBlock: cdk.Fn.select(1, cdk.Fn.cidr(vpc.attrCidrBlock, 6, String(8))),
       vpcId: vpc.ref,
     });
 
-    if (vpc == null) { throw new Error(`A combination of conditions caused 'vpc' to be undefined. Fixit.`); }
     const subnet3 = new ec2.CfnSubnet(this, 'Subnet3', {
       availabilityZone: cdk.Fn.select(2, cdk.Fn.getAzs('')),
       cidrBlock: cdk.Fn.select(2, cdk.Fn.cidr(vpc.attrCidrBlock, 6, String(8))),


### PR DESCRIPTION
These are of no use to the end user and just add noise to the template.

Note that with this change, the integ tests in aws-cdk will likely need to be updated manually.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
