### PR TITLE
fix(csharp): setting default prop value uses incorrect props class name

### DIFF
--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -118,7 +118,7 @@ impl Synthesizer for CSharp {
             .collect::<Vec<&ConstructorParameter>>();
         if !have_default_or_special_type_params.is_empty() {
             ctor.line("// Applying default props");
-            ctor.line("props ??= new SimpleStackProps();");
+            ctor.line(format!("props ??= new {stack_name}Props();"));
             for param in have_default_or_special_type_params {
                 let name = pascal_case(&param.name);
                 // example: AWS::EC2::Image::Id, List<AWS::EC2::VPC::Id>, AWS::SSM::Parameter::Value<List<String>>

--- a/tests/end-to-end/config/App.cs
+++ b/tests/end-to-end/config/App.cs
@@ -32,7 +32,7 @@ namespace ConfigStack
         public ConfigStack(Construct scope, string id, ConfigStackProps props = null) : base(scope, id, props)
         {
             // Applying default props
-            props ??= new SimpleStackProps();
+            props ??= new ConfigStackProps();
             props.Ec2VolumeAutoEnableIo ??= false;
             props.Ec2VolumeTagKey ??= "CostCenter";
 

--- a/tests/end-to-end/documentdb/App.cs
+++ b/tests/end-to-end/documentdb/App.cs
@@ -50,7 +50,7 @@ namespace DocumentDbStack
         public DocumentDbStack(Construct scope, string id, DocumentDbStackProps props = null) : base(scope, id, props)
         {
             // Applying default props
-            props ??= new SimpleStackProps();
+            props ??= new DocumentDbStackProps();
             props.DbClusterName ??= "MyCluster";
             props.DbInstanceName ??= "MyInstance";
 


### PR DESCRIPTION
This was unintentionally hard-coded in a previous change to the name of the stack props in one of the end-to-end test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
