### PR TITLE
test(java): update boilerplate pom.xml to use the same versions as aws-cdk

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -55,6 +55,11 @@ jobs:
         run: rustup update stable
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 17
       - name: Tests with Coverage
         run: cargo llvm-cov --all-features --ignore-filename-regex '^(tests/.*\.rs|.*/tests\.rs)$' --no-fail-fast --lcov --output-path target/lcov.info
       - name: Coverage Report

--- a/tests/end-to-end/app-boilerplate-files/java/pom.xml
+++ b/tests/end-to-end/app-boilerplate-files/java/pom.xml
@@ -9,8 +9,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.117.0</cdk.version>
+        <cdk.version>2.119.0</cdk.version>
         <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <junit.version>5.7.1</junit.version>
     </properties>
 
     <build>
@@ -18,17 +19,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>17</release>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <configuration>
                     <mainClass>com.myorg.MyApp</mainClass>
                 </configuration>
@@ -48,6 +48,13 @@
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
             <version>${constructs.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/tests/end-to-end/app-boilerplate-files/java/pom.xml
+++ b/tests/end-to-end/app-boilerplate-files/java/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <mainClass>com.myorg.MyApp</mainClass>
                 </configuration>

--- a/tests/end-to-end/app-boilerplate-files/java/setup-and-synth.sh
+++ b/tests/end-to-end/app-boilerplate-files/java/setup-and-synth.sh
@@ -4,4 +4,4 @@ set -eu
 echo "java setup"
 
 echo "cdk synth"
-npx --yes cdk@latest synth --no-version-reporting --no-path-metadata --app 'mvn -e -q compile exec:java'
+npx --yes cdk@latest synth --no-version-reporting --no-path-metadata --app 'mvn -e -q package'

--- a/tests/end-to-end/app-boilerplate-files/java/setup-and-synth.sh
+++ b/tests/end-to-end/app-boilerplate-files/java/setup-and-synth.sh
@@ -4,4 +4,4 @@ set -eu
 echo "java setup"
 
 echo "cdk synth"
-npx --yes cdk@latest synth --no-version-reporting --no-path-metadata
+npx --yes cdk@latest synth --no-version-reporting --no-path-metadata --app 'mvn -e -q compile exec:java'

--- a/tests/end-to-end/app-boilerplate-files/java/setup-and-synth.sh
+++ b/tests/end-to-end/app-boilerplate-files/java/setup-and-synth.sh
@@ -4,4 +4,4 @@ set -eu
 echo "java setup"
 
 echo "cdk synth"
-npx --yes cdk@latest synth --no-version-reporting --no-path-metadata --app 'mvn -e -q package'
+npx --yes cdk@latest synth --no-version-reporting --no-path-metadata


### PR DESCRIPTION
The pom.xml file we are using here is for Java 8 but the cdk uses Java 17.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
