### PR TITLE
fix(release): npm release is not using CSharp default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ where
 
 #[cfg(target_family = "wasm")]
 pub mod wasm {
+    use cdk::Schema;
     use wasm_bindgen::prelude::*;
 
     use super::*;
@@ -94,7 +95,8 @@ pub mod wasm {
     #[wasm_bindgen]
     pub fn transmute(template: &str, language: &str, stack_name: &str) -> Result<String, JsError> {
         let cfn_tree: CloudformationParseTree = serde_yaml::from_str(template)?;
-        let ir = crate::ir::CloudformationProgramIr::from(cfn_tree)?;
+        let schema = Cow::Borrowed(Schema::builtin());
+        let ir = crate::ir::CloudformationProgramIr::from(cfn_tree, &schema)?;
         let mut output = Vec::new();
 
         let synthesizer: Box<dyn crate::synthesizer::Synthesizer> = match language {
@@ -107,7 +109,7 @@ pub mod wasm {
             #[cfg(feature = "java")]
             "java" => Box::<crate::synthesizer::Java>::default(),
             #[cfg(feature = "csharp")]
-            "csharp" => Box::new(crate::synthesizer::CSharp {}),
+            "csharp" => Box::<crate::synthesizer::CSharp>::default(),
             unsupported => panic!("unsupported language: {}", unsupported),
         };
 


### PR DESCRIPTION
The npm release is failing due to the settings for CSharp not being updated in the wasm_bindgen configuation. This fixes that.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
