### PR TITLE
fix(all): noEcho parameters still show in deployed template

### DIFF
--- a/src/ir/constructor/mod.rs
+++ b/src/ir/constructor/mod.rs
@@ -35,6 +35,7 @@ impl Constructor {
                     },
                     default_value: param.default,
                     allowed_values: param.allowed_values,
+                    no_echo: param.no_echo,
                 })
                 .collect(),
         }
@@ -47,6 +48,7 @@ pub struct ConstructorParameter {
     pub constructor_type: String,
     pub default_value: Option<String>,
     pub allowed_values: Option<Vec<String>>,
+    pub no_echo: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/ir/constructor/tests.rs
+++ b/src/ir/constructor/tests.rs
@@ -13,6 +13,7 @@ fn test_constructor_from() {
             default: Some("default1".to_string()),
             description: Some("description1".to_string()),
             parameter_type: ParameterType::String,
+            no_echo: None,
         },
     );
     parse_tree.insert(
@@ -22,6 +23,7 @@ fn test_constructor_from() {
             default: None,
             description: Some("description2".to_string()),
             parameter_type: ParameterType::Number,
+            no_echo: None,
         },
     );
 
@@ -59,6 +61,7 @@ fn test_constructor_parameter() {
         constructor_type: "String".to_string(),
         default_value: Some("default1".to_string()),
         allowed_values: Some(vec!["true".to_string(), "false".to_string()]),
+        no_echo: None,
     };
 
     assert_eq!(param.name, "Param1");

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -64,12 +64,17 @@ impl ReferenceOrigins {
     fn new(parse_tree: &CloudformationParseTree) -> Self {
         let mut origins = HashMap::default();
 
-        origins.extend(
-            parse_tree
-                .parameters
-                .iter()
-                .map(|(name, _)| (name.clone(), Origin::Parameter)),
-        );
+        origins.extend(parse_tree.parameters.iter().map(|(name, param)| {
+            if param
+                .no_echo
+                .as_ref()
+                .is_some_and(|x| x.to_lowercase() == "true")
+            {
+                (name.clone(), Origin::CfnParameter)
+            } else {
+                (name.clone(), Origin::Parameter)
+            }
+        }));
 
         origins.extend(parse_tree.resources.iter().map(|(name, res)| {
             (

--- a/src/ir/reference/mod.rs
+++ b/src/ir/reference/mod.rs
@@ -17,6 +17,7 @@ impl Reference {
 // Origin for the ReferenceTable
 #[derive(Debug, Clone, PartialEq)]
 pub enum Origin {
+    CfnParameter,
     Parameter,
     LogicalId {
         conditional: bool,

--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -610,8 +610,10 @@ pub(crate) fn find_references(resource: &ResourceIr) -> HashSet<String> {
         }
         ResourceIr::Split(_, ir) => set = find_references(ir),
         ResourceIr::Ref(x) => match x.origin {
-            Origin::Parameter | Origin::Condition | Origin::PseudoParameter(_) => { /* No references */
-            }
+            Origin::CfnParameter
+            | Origin::Parameter
+            | Origin::Condition
+            | Origin::PseudoParameter(_) => { /* No references */ }
             Origin::GetAttribute { .. } | Origin::LogicalId { .. } => {
                 set.insert(x.name.clone());
             }
@@ -672,7 +674,10 @@ fn find_dependencies(
         }
         ResourceIr::Split(_, ir) => find_dependencies(resource_name, ir, topo),
         ResourceIr::Ref(x) => match x.origin {
-            Origin::Parameter | Origin::Condition | Origin::PseudoParameter(_) => {}
+            Origin::CfnParameter
+            | Origin::Parameter
+            | Origin::Condition
+            | Origin::PseudoParameter(_) => {}
             Origin::LogicalId { .. } => {
                 topo.add_dependency(x.name.to_string(), resource_name.to_string());
             }

--- a/src/parser/parameters/mod.rs
+++ b/src/parser/parameters/mod.rs
@@ -8,6 +8,7 @@ pub struct Parameter {
     pub description: Option<String>,
     #[serde(rename = "Type")]
     pub parameter_type: ParameterType,
+    pub no_echo: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, serde_enum_str::Deserialize_enum_str)]

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -960,7 +960,7 @@ impl GolangEmitter for Reference {
                 "{name}.Ref()",
                 name = golang_identifier(&self.name, IdentifierKind::Unexported)
             )),
-            Origin::Parameter => output.text(format!(
+            Origin::CfnParameter | Origin::Parameter => output.text(format!(
                 "props.{name}",
                 name = golang_identifier(&self.name, IdentifierKind::Exported)
             )),

--- a/tests/end-to-end/documentdb/csharp/Stack.cs
+++ b/tests/end-to-end/documentdb/csharp/Stack.cs
@@ -53,8 +53,20 @@ namespace DocumentDbStack
             props ??= new DocumentDbStackProps();
             props.DbClusterName ??= "MyCluster";
             props.DbInstanceName ??= "MyInstance";
-            props.MasterUser ??= "MainUser";
-            props.MasterPassword ??= "password";
+            props.MasterUser = new CfnParameter(this, "MasterUser", new CfnParameterProps
+            {
+                Type = "String",
+                Default = props.MasterUser ?? "MainUser",
+                Description = "The database admin account username",
+                NoEcho = true,
+            }).ValueAsString;
+            props.MasterPassword = new CfnParameter(this, "MasterPassword", new CfnParameterProps
+            {
+                Type = "String",
+                Default = props.MasterPassword ?? "password",
+                Description = "The database admin account password",
+                NoEcho = true,
+            }).ValueAsString;
             props.DbInstanceClass ??= "db.t3.medium";
 
 

--- a/tests/end-to-end/documentdb/csharp/Stack.diff
+++ b/tests/end-to-end/documentdb/csharp/Stack.diff
@@ -1,11 +1,11 @@
 diff --git a/./tests/end-to-end/documentdb/template.json b/tests/end-to-end/documentdb-csharp-working-dir/cdk.out/Stack.template.json
-index efdfe54..d1012e6 100644
+index efdfe54..1bb8789 100644
 --- a/./tests/end-to-end/documentdb/template.json
 +++ b/tests/end-to-end/documentdb-csharp-working-dir/cdk.out/Stack.template.json
-@@ -1,75 +1,12 @@
+@@ -1,75 +1,30 @@
  {
 - "Description": "AWS CloudFormation Sample Template DocumentDB_Quick_Create: Sample template showing how to create a DocumentDB DB cluster and DB instance. **WARNING** This template creates an Amazon DocumentDB resources and you will be billed for the AWS resources used if you create a stack from this template.",
-- "Parameters": {
+  "Parameters": {
 -  "DBClusterName": {
 -   "Default": "MyCluster",
 -   "Description": "Cluster name",
@@ -24,20 +24,23 @@ index efdfe54..d1012e6 100644
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*",
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
 -  },
--  "MasterUser": {
--   "Default": "MainUser",
+   "MasterUser": {
++   "Type": "String",
+    "Default": "MainUser",
 -   "NoEcho": "true",
--   "Description": "The database admin account username",
+    "Description": "The database admin account username",
 -   "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "16",
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*",
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
--  },
--  "MasterPassword": {
--   "Default": "password",
++   "NoEcho": true
+   },
+   "MasterPassword": {
++   "Type": "String",
+    "Default": "password",
 -   "NoEcho": "true",
--   "Description": "The database admin account password",
+    "Description": "The database admin account password",
 -   "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "41",
@@ -58,8 +61,9 @@ index efdfe54..d1012e6 100644
 -    "db.r5.24xlarge"
 -   ],
 -   "ConstraintDescription": "Instance type must be of the ones supported for the region. Please refer to: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-classes-by-region"
--  }
-- },
++   "NoEcho": true
+   }
+  },
   "Resources": {
    "DBCluster": {
     "Type": "AWS::DocDB::DBCluster",
@@ -71,18 +75,19 @@ index efdfe54..d1012e6 100644
 -    "MasterUsername": {
 -     "Ref": "MasterUser"
 -    },
--    "MasterUserPassword": {
--     "Ref": "MasterPassword"
--    },
--    "EngineVersion": "4.0.0"
 +    "DBClusterIdentifier": "MyCluster",
 +    "EngineVersion": "4.0.0",
-+    "MasterUserPassword": "password",
-+    "MasterUsername": "MainUser"
+     "MasterUserPassword": {
+      "Ref": "MasterPassword"
+     },
+-    "EngineVersion": "4.0.0"
++    "MasterUsername": {
++     "Ref": "MasterUser"
++    }
     }
    },
    "DBInstance": {
-@@ -78,34 +15,9 @@
+@@ -78,34 +33,9 @@
      "DBClusterIdentifier": {
       "Ref": "DBCluster"
      },
@@ -91,9 +96,7 @@ index efdfe54..d1012e6 100644
 -    },
 -    "DBInstanceClass": {
 -     "Ref": "DBInstanceClass"
-+    "DBInstanceClass": "db.t3.medium",
-+    "DBInstanceIdentifier": "MyInstance"
-    }
+-    }
 -   },
 -   "DependsOn": "DBCluster"
 -  }
@@ -107,7 +110,9 @@ index efdfe54..d1012e6 100644
 -  "ClusterEndpoint": {
 -   "Value": {
 -    "Fn::GetAtt": "DBCluster.Endpoint"
--   }
++    "DBInstanceClass": "db.t3.medium",
++    "DBInstanceIdentifier": "MyInstance"
+    }
 -  },
 -  "ClusterPort": {
 -   "Value": {

--- a/tests/end-to-end/documentdb/csharp/Stack.template.json
+++ b/tests/end-to-end/documentdb/csharp/Stack.template.json
@@ -1,12 +1,30 @@
 {
+ "Parameters": {
+  "MasterUser": {
+   "Type": "String",
+   "Default": "MainUser",
+   "Description": "The database admin account username",
+   "NoEcho": true
+  },
+  "MasterPassword": {
+   "Type": "String",
+   "Default": "password",
+   "Description": "The database admin account password",
+   "NoEcho": true
+  }
+ },
  "Resources": {
   "DBCluster": {
    "Type": "AWS::DocDB::DBCluster",
    "Properties": {
     "DBClusterIdentifier": "MyCluster",
     "EngineVersion": "4.0.0",
-    "MasterUserPassword": "password",
-    "MasterUsername": "MainUser"
+    "MasterUserPassword": {
+     "Ref": "MasterPassword"
+    },
+    "MasterUsername": {
+     "Ref": "MasterUser"
+    }
    }
   },
   "DBInstance": {

--- a/tests/end-to-end/documentdb/java/Stack.diff
+++ b/tests/end-to-end/documentdb/java/Stack.diff
@@ -1,11 +1,11 @@
 diff --git a/./tests/end-to-end/documentdb/template.json b/tests/end-to-end/documentdb-java-working-dir/cdk.out/Stack.template.json
-index efdfe54..7740b1a 100644
+index efdfe54..7567847 100644
 --- a/./tests/end-to-end/documentdb/template.json
 +++ b/tests/end-to-end/documentdb-java-working-dir/cdk.out/Stack.template.json
-@@ -1,76 +1,15 @@
+@@ -1,91 +1,44 @@
  {
 - "Description": "AWS CloudFormation Sample Template DocumentDB_Quick_Create: Sample template showing how to create a DocumentDB DB cluster and DB instance. **WARNING** This template creates an Amazon DocumentDB resources and you will be billed for the AWS resources used if you create a stack from this template.",
-- "Parameters": {
+  "Parameters": {
 -  "DBClusterName": {
 -   "Default": "MyCluster",
 -   "Description": "Cluster name",
@@ -24,21 +24,23 @@ index efdfe54..7740b1a 100644
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*",
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
 -  },
--  "MasterUser": {
+   "MasterUser": {
 -   "Default": "MainUser",
 -   "NoEcho": "true",
 -   "Description": "The database admin account username",
--   "Type": "String",
+    "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "16",
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*",
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
--  },
--  "MasterPassword": {
++   "Default": "MainUser",
++   "NoEcho": true
+   },
+   "MasterPassword": {
 -   "Default": "password",
 -   "NoEcho": "true",
 -   "Description": "The database admin account password",
--   "Type": "String",
+    "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "41",
 -   "AllowedPattern": "[a-zA-Z0-9]+",
@@ -58,8 +60,10 @@ index efdfe54..7740b1a 100644
 -    "db.r5.24xlarge"
 -   ],
 -   "ConstraintDescription": "Instance type must be of the ones supported for the region. Please refer to: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-classes-by-region"
--  }
-- },
++   "Default": "password",
++   "NoEcho": true
+   }
+  },
   "Resources": {
    "DBCluster": {
     "Type": "AWS::DocDB::DBCluster",
@@ -71,21 +75,22 @@ index efdfe54..7740b1a 100644
 -    "MasterUsername": {
 -     "Ref": "MasterUser"
 -    },
--    "MasterUserPassword": {
--     "Ref": "MasterPassword"
 +    "DBClusterIdentifier": "MyCluster",
 +    "EngineVersion": "4.0.0",
-+    "MasterUserPassword": "password",
-+    "MasterUsername": "MainUser"
-    },
+     "MasterUserPassword": {
+      "Ref": "MasterPassword"
+     },
 -    "EngineVersion": "4.0.0"
--   }
++    "MasterUsername": {
++     "Ref": "MasterUser"
+     }
+    },
 +   "UpdateReplacePolicy": "Delete",
 +   "DeletionPolicy": "Delete"
-   },
++  },
    "DBInstance": {
     "Type": "AWS::DocDB::DBInstance",
-@@ -78,14 +17,12 @@
+    "Properties": {
      "DBClusterIdentifier": {
       "Ref": "DBCluster"
      },
@@ -105,7 +110,7 @@ index efdfe54..7740b1a 100644
    }
   },
   "Outputs": {
-@@ -96,12 +33,18 @@
+@@ -96,12 +49,18 @@
    },
    "ClusterEndpoint": {
     "Value": {

--- a/tests/end-to-end/documentdb/java/Stack.template.json
+++ b/tests/end-to-end/documentdb/java/Stack.template.json
@@ -1,12 +1,28 @@
 {
+ "Parameters": {
+  "MasterUser": {
+   "Type": "String",
+   "Default": "MainUser",
+   "NoEcho": true
+  },
+  "MasterPassword": {
+   "Type": "String",
+   "Default": "password",
+   "NoEcho": true
+  }
+ },
  "Resources": {
   "DBCluster": {
    "Type": "AWS::DocDB::DBCluster",
    "Properties": {
     "DBClusterIdentifier": "MyCluster",
     "EngineVersion": "4.0.0",
-    "MasterUserPassword": "password",
-    "MasterUsername": "MainUser"
+    "MasterUserPassword": {
+     "Ref": "MasterPassword"
+    },
+    "MasterUsername": {
+     "Ref": "MasterUser"
+    }
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/tests/end-to-end/documentdb/java/src/main/java/com/myorg/Stack.java
+++ b/tests/end-to-end/documentdb/java/src/main/java/com/myorg/Stack.java
@@ -56,10 +56,24 @@ class DocumentDbStack extends Stack {
                 : "MyCluster";
         dbInstanceName = Optional.ofNullable(dbInstanceName).isPresent() ? dbInstanceName
                 : "MyInstance";
-        masterUser = Optional.ofNullable(masterUser).isPresent() ? masterUser
-                : "MainUser";
-        masterPassword = Optional.ofNullable(masterPassword).isPresent() ? masterPassword
-                : "password";
+        masterUser = Optional.ofNullable(masterUser).isPresent()
+                ? masterUser
+                : CfnParameter.Builder.create(this, "MasterUser")
+                        .type("String")
+                        .defaultValue("MainUser")
+                        .noEcho(true)
+                        .build()
+                        .getValueAsString();
+
+        masterPassword = Optional.ofNullable(masterPassword).isPresent()
+                ? masterPassword
+                : CfnParameter.Builder.create(this, "MasterPassword")
+                        .type("String")
+                        .defaultValue("password")
+                        .noEcho(true)
+                        .build()
+                        .getValueAsString();
+
         dbInstanceClass = Optional.ofNullable(dbInstanceClass).isPresent() ? dbInstanceClass
                 : "db.t3.medium";
 

--- a/tests/end-to-end/documentdb/python/Stack.diff
+++ b/tests/end-to-end/documentdb/python/Stack.diff
@@ -1,15 +1,16 @@
 diff --git a/./tests/end-to-end/documentdb/template.json b/tests/end-to-end/documentdb-python-working-dir/cdk.out/Stack.template.json
-index efdfe54..2ebebc1 100644
+index efdfe54..b947438 100644
 --- a/./tests/end-to-end/documentdb/template.json
 +++ b/tests/end-to-end/documentdb-python-working-dir/cdk.out/Stack.template.json
-@@ -1,76 +1,14 @@
+@@ -1,91 +1,45 @@
  {
 - "Description": "AWS CloudFormation Sample Template DocumentDB_Quick_Create: Sample template showing how to create a DocumentDB DB cluster and DB instance. **WARNING** This template creates an Amazon DocumentDB resources and you will be billed for the AWS resources used if you create a stack from this template.",
-- "Parameters": {
+  "Parameters": {
 -  "DBClusterName": {
 -   "Default": "MyCluster",
 -   "Description": "Cluster name",
--   "Type": "String",
++  "masterUser": {
+    "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "64",
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*",
@@ -25,19 +26,22 @@ index efdfe54..2ebebc1 100644
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
 -  },
 -  "MasterUser": {
--   "Default": "MainUser",
+    "Default": "MainUser",
 -   "NoEcho": "true",
--   "Description": "The database admin account username",
+    "Description": "The database admin account username",
 -   "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "16",
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*",
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
--  },
++   "NoEcho": true
+   },
 -  "MasterPassword": {
--   "Default": "password",
++  "masterPassword": {
++   "Type": "String",
+    "Default": "password",
 -   "NoEcho": "true",
--   "Description": "The database admin account password",
+    "Description": "The database admin account password",
 -   "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "41",
@@ -58,8 +62,9 @@ index efdfe54..2ebebc1 100644
 -    "db.r5.24xlarge"
 -   ],
 -   "ConstraintDescription": "Instance type must be of the ones supported for the region. Please refer to: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-classes-by-region"
--  }
-- },
++   "NoEcho": true
+   }
+  },
   "Resources": {
    "DBCluster": {
     "Type": "AWS::DocDB::DBCluster",
@@ -71,20 +76,22 @@ index efdfe54..2ebebc1 100644
 -    "MasterUsername": {
 -     "Ref": "MasterUser"
 -    },
--    "MasterUserPassword": {
--     "Ref": "MasterPassword"
 +    "DBClusterIdentifier": "MyCluster",
 +    "EngineVersion": "4.0.0",
-+    "MasterUserPassword": "password",
-+    "MasterUsername": "MainUser"
-    },
+     "MasterUserPassword": {
+-     "Ref": "MasterPassword"
++     "Ref": "masterPassword"
+     },
 -    "EngineVersion": "4.0.0"
--   }
++    "MasterUsername": {
++     "Ref": "masterUser"
+     }
+    },
 +   "DeletionPolicy": "Delete"
-   },
++  },
    "DBInstance": {
     "Type": "AWS::DocDB::DBInstance",
-@@ -78,14 +16,12 @@
+    "Properties": {
      "DBClusterIdentifier": {
       "Ref": "DBCluster"
      },
@@ -104,7 +111,7 @@ index efdfe54..2ebebc1 100644
    }
   },
   "Outputs": {
-@@ -96,12 +32,18 @@
+@@ -96,12 +50,18 @@
    },
    "ClusterEndpoint": {
     "Value": {

--- a/tests/end-to-end/documentdb/python/Stack.template.json
+++ b/tests/end-to-end/documentdb/python/Stack.template.json
@@ -1,12 +1,30 @@
 {
+ "Parameters": {
+  "masterUser": {
+   "Type": "String",
+   "Default": "MainUser",
+   "Description": "The database admin account username",
+   "NoEcho": true
+  },
+  "masterPassword": {
+   "Type": "String",
+   "Default": "password",
+   "Description": "The database admin account password",
+   "NoEcho": true
+  }
+ },
  "Resources": {
   "DBCluster": {
    "Type": "AWS::DocDB::DBCluster",
    "Properties": {
     "DBClusterIdentifier": "MyCluster",
     "EngineVersion": "4.0.0",
-    "MasterUserPassword": "password",
-    "MasterUsername": "MainUser"
+    "MasterUserPassword": {
+     "Ref": "masterPassword"
+    },
+    "MasterUsername": {
+     "Ref": "masterUser"
+    }
    },
    "DeletionPolicy": "Delete"
   },

--- a/tests/end-to-end/documentdb/python/stack.py
+++ b/tests/end-to-end/documentdb/python/stack.py
@@ -14,16 +14,26 @@ class DocumentDbStack(Stack):
     props = {
       'dbClusterName': kwargs.get('dbClusterName', 'MyCluster'),
       'dbInstanceName': kwargs.get('dbInstanceName', 'MyInstance'),
-      'masterUser': kwargs.get('masterUser', 'MainUser'),
-      'masterPassword': kwargs.get('masterPassword', 'password'),
+      'masterUser': cdk.CfnParameter(self, 'masterUser', 
+        type = 'String',
+        default = str(kwargs.get('masterUser', 'MainUser')),
+        description = 'The database admin account username',
+        no_echo = True,
+      ),
+      'masterPassword': cdk.CfnParameter(self, 'masterPassword', 
+        type = 'String',
+        default = str(kwargs.get('masterPassword', 'password')),
+        description = 'The database admin account password',
+        no_echo = True,
+      ),
       'dbInstanceClass': kwargs.get('dbInstanceClass', 'db.t3.medium'),
     }
 
     # Resources
     dbCluster = docdb.CfnDBCluster(self, 'DBCluster',
           db_cluster_identifier = props['dbClusterName'],
-          master_username = props['masterUser'],
-          master_user_password = props['masterPassword'],
+          master_username = props['masterUser'].value_as_string,
+          master_user_password = props['masterPassword'].value_as_string,
           engine_version = '4.0.0',
         )
     dbCluster.cfn_options.deletion_policy = cdk.CfnDeletionPolicy.DELETE

--- a/tests/end-to-end/documentdb/typescript/Stack.diff
+++ b/tests/end-to-end/documentdb/typescript/Stack.diff
@@ -1,11 +1,11 @@
 diff --git a/./tests/end-to-end/documentdb/template.json b/tests/end-to-end/documentdb-typescript-working-dir/cdk.out/Stack.template.json
-index efdfe54..2ebebc1 100644
+index efdfe54..1b291ae 100644
 --- a/./tests/end-to-end/documentdb/template.json
 +++ b/tests/end-to-end/documentdb-typescript-working-dir/cdk.out/Stack.template.json
-@@ -1,76 +1,14 @@
+@@ -1,91 +1,45 @@
  {
 - "Description": "AWS CloudFormation Sample Template DocumentDB_Quick_Create: Sample template showing how to create a DocumentDB DB cluster and DB instance. **WARNING** This template creates an Amazon DocumentDB resources and you will be billed for the AWS resources used if you create a stack from this template.",
-- "Parameters": {
+  "Parameters": {
 -  "DBClusterName": {
 -   "Default": "MyCluster",
 -   "Description": "Cluster name",
@@ -24,20 +24,23 @@ index efdfe54..2ebebc1 100644
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*",
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
 -  },
--  "MasterUser": {
--   "Default": "MainUser",
+   "MasterUser": {
++   "Type": "String",
+    "Default": "MainUser",
 -   "NoEcho": "true",
--   "Description": "The database admin account username",
+    "Description": "The database admin account username",
 -   "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "16",
 -   "AllowedPattern": "[a-zA-Z][a-zA-Z0-9]*",
 -   "ConstraintDescription": "Must begin with a letter and contain only alphanumeric characters."
--  },
--  "MasterPassword": {
--   "Default": "password",
++   "NoEcho": true
+   },
+   "MasterPassword": {
++   "Type": "String",
+    "Default": "password",
 -   "NoEcho": "true",
--   "Description": "The database admin account password",
+    "Description": "The database admin account password",
 -   "Type": "String",
 -   "MinLength": "1",
 -   "MaxLength": "41",
@@ -58,8 +61,9 @@ index efdfe54..2ebebc1 100644
 -    "db.r5.24xlarge"
 -   ],
 -   "ConstraintDescription": "Instance type must be of the ones supported for the region. Please refer to: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-classes-by-region"
--  }
-- },
++   "NoEcho": true
+   }
+  },
   "Resources": {
    "DBCluster": {
     "Type": "AWS::DocDB::DBCluster",
@@ -71,20 +75,21 @@ index efdfe54..2ebebc1 100644
 -    "MasterUsername": {
 -     "Ref": "MasterUser"
 -    },
--    "MasterUserPassword": {
--     "Ref": "MasterPassword"
 +    "DBClusterIdentifier": "MyCluster",
 +    "EngineVersion": "4.0.0",
-+    "MasterUserPassword": "password",
-+    "MasterUsername": "MainUser"
-    },
+     "MasterUserPassword": {
+      "Ref": "MasterPassword"
+     },
 -    "EngineVersion": "4.0.0"
--   }
++    "MasterUsername": {
++     "Ref": "MasterUser"
+     }
+    },
 +   "DeletionPolicy": "Delete"
-   },
++  },
    "DBInstance": {
     "Type": "AWS::DocDB::DBInstance",
-@@ -78,14 +16,12 @@
+    "Properties": {
      "DBClusterIdentifier": {
       "Ref": "DBCluster"
      },
@@ -104,7 +109,7 @@ index efdfe54..2ebebc1 100644
    }
   },
   "Outputs": {
-@@ -96,12 +32,18 @@
+@@ -96,12 +50,18 @@
    },
    "ClusterEndpoint": {
     "Value": {

--- a/tests/end-to-end/documentdb/typescript/Stack.template.json
+++ b/tests/end-to-end/documentdb/typescript/Stack.template.json
@@ -1,12 +1,30 @@
 {
+ "Parameters": {
+  "MasterUser": {
+   "Type": "String",
+   "Default": "MainUser",
+   "Description": "The database admin account username",
+   "NoEcho": true
+  },
+  "MasterPassword": {
+   "Type": "String",
+   "Default": "password",
+   "Description": "The database admin account password",
+   "NoEcho": true
+  }
+ },
  "Resources": {
   "DBCluster": {
    "Type": "AWS::DocDB::DBCluster",
    "Properties": {
     "DBClusterIdentifier": "MyCluster",
     "EngineVersion": "4.0.0",
-    "MasterUserPassword": "password",
-    "MasterUsername": "MainUser"
+    "MasterUserPassword": {
+     "Ref": "MasterPassword"
+    },
+    "MasterUsername": {
+     "Ref": "MasterUser"
+    }
    },
    "DeletionPolicy": "Delete"
   },

--- a/tests/end-to-end/documentdb/typescript/stack.ts
+++ b/tests/end-to-end/documentdb/typescript/stack.ts
@@ -46,8 +46,18 @@ export class DocumentDbStack extends cdk.Stack {
       ...props,
       dbClusterName: props.dbClusterName ?? 'MyCluster',
       dbInstanceName: props.dbInstanceName ?? 'MyInstance',
-      masterUser: props.masterUser ?? 'MainUser',
-      masterPassword: props.masterPassword ?? 'password',
+      masterUser: new cdk.CfnParameter(this, 'MasterUser', {
+        type: 'String',
+        default: props.masterUser?.toString() ?? 'MainUser',
+        description: 'The database admin account username',
+        noEcho: true,
+      }).valueAsString,
+      masterPassword: new cdk.CfnParameter(this, 'MasterPassword', {
+        type: 'String',
+        default: props.masterPassword?.toString() ?? 'password',
+        description: 'The database admin account password',
+        noEcho: true,
+      }).valueAsString,
       dbInstanceClass: props.dbInstanceClass ?? 'db.t3.medium',
     };
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -691,6 +691,7 @@ fn test_parse_tree_resource_with_fn_and() {
                     description: Option::None,
                     allowed_values: Option::Some(vec!["dev".into(), "test".into(), "prod".into()]),
                     default: Option::Some("dev".into()),
+                    no_echo: None,
                 },
             ),
             (
@@ -700,6 +701,7 @@ fn test_parse_tree_resource_with_fn_and() {
                     description: Option::None,
                     allowed_values: Option::Some(vec!["mysql".into(), "postgresql".into()]),
                     default: Option::Some("postgresql".into()),
+                    no_echo: None,
                 },
             ),
             (
@@ -709,6 +711,7 @@ fn test_parse_tree_resource_with_fn_and() {
                     description: Option::None,
                     allowed_values: Option::Some(vec!["true".into(), "false".into()]),
                     default: Option::Some("false".into()),
+                    no_echo: None,
                 },
             ),
             (
@@ -718,6 +721,7 @@ fn test_parse_tree_resource_with_fn_and() {
                     description: Option::None,
                     allowed_values: Option::None,
                     default: Option::Some("ami-1234567890abcdef0".into()),
+                    no_echo: None,
                 },
             ),
             (
@@ -727,6 +731,7 @@ fn test_parse_tree_resource_with_fn_and() {
                     description: Option::None,
                     allowed_values: Option::None,
                     default: Option::Some("ami-0987654321fedcba0".into()),
+                    no_echo: None,
                 },
             ),
         ]),


### PR DESCRIPTION
If a user supplies a template that contains parameters wiht noEcho set to true, we are currently not translating that in a way that prevents it from showing in the stack. This adds handling to make parameters wtih noEcho into CfnParameters with the same set.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
