### PR TITLE
chore: address clippy recommendations

### DIFF
--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -120,7 +120,7 @@ impl<'a> Java<'a> {
     }
 
     fn write_stack_definitions(
-        props: &Vec<JavaConstructorParameter>,
+        props: &[JavaConstructorParameter],
         writer: &CodeBuffer,
         stack_name: &str,
     ) -> Rc<CodeBuffer> {
@@ -176,7 +176,7 @@ impl<'a> Java<'a> {
         }
     }
 
-    fn write_props(props: &Vec<JavaConstructorParameter>, writer: &CodeBuffer) {
+    fn write_props(props: &[JavaConstructorParameter], writer: &CodeBuffer) {
         for prop in props {
             match &prop.default_value {
                 None => writer.newline(),


### PR DESCRIPTION
I am seeing [workflows](https://github.com/cdklabs/cdk-from-cfn/actions/runs/7844052695/job/21405613049?pr=558) fail for this repo due to clippy error:

```
error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
Error:    --> src/synthesizer/java/mod.rs:123:16
    |
123 |         props: &Vec<JavaConstructorParameter>,
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[JavaConstructorParameter]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `-D clippy::ptr-arg` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::ptr_arg)]`

error: could not compile `cdk-from-cfn` (lib) due to 1 previous error
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```

Following clippy recommendation and updating the code.
