### PR TITLE
chore: update readme user guide to use correct release binary file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cdk_from_cfn will take your JSON/YAML and output the equivalent typescript.
 
 ```console
 $ cargo build --release
-$ ./target/release/cdk_from_cfn [INPUT] [OUTPUT]
+$ ./target/release/cdk-from-cfn [INPUT] [OUTPUT]
 ```
 
 - `INPUT` is the input file path (STDIN by default).


### PR DESCRIPTION
The `README` user guide section contains the following instructions:
```
$ cargo build --release
$ ./target/release/cdk_from_cfn [INPUT] [OUTPUT]
```

However, after running `cargo build --release` the following `target` directory is created:

![image](https://github.com/cdklabs/cdk-from-cfn/assets/131073567/56e72ea6-88ed-498b-8cb3-be33427b0518)

As shown, the `target` directory contains a `release` directory with `cdk-from-cfn`, not `cdk_from_cfn`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
