### PR TITLE
chore(ir): add specific error message when an invalid resource property is used

### DIFF
--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -402,7 +402,7 @@ impl ResourceInstruction {
                     )
                     .replace('\"', "");
                     return Err(TransmuteError::new(format!(
-                        "{name} is not a valid property type for resource type {resource_type}"
+                        "{name} is not a valid property for resource type {resource_type}"
                     )));
                 }
                 let translator = ResourceTranslator {

--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -393,6 +393,17 @@ impl ResourceInstruction {
             for (name, prop) in attributes.properties {
                 let property_type = resource_spec.and_then(|spec| spec.property(&name));
                 let property_type = property_type.map(|prop| prop.value_type);
+                if property_type.is_none() {
+                    let resource_type = format!(
+                        "{:#?}::{:#?}::{:#?}",
+                        resource_type.scope().to_uppercase(),
+                        resource_type.service(),
+                        resource_type.type_name(),
+                    ).replace("\"", "");
+                    return Err(TransmuteError::new(format!(
+                        "{name} is not a valid property type for resource type {resource_type}"
+                    )));
+                }
                 let translator = ResourceTranslator {
                     schema,
                     origins,

--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -400,7 +400,7 @@ impl ResourceInstruction {
                         resource_type.service(),
                         resource_type.type_name(),
                     )
-                    .replace("\"", "");
+                    .replace('\"', "");
                     return Err(TransmuteError::new(format!(
                         "{name} is not a valid property type for resource type {resource_type}"
                     )));

--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -399,7 +399,8 @@ impl ResourceInstruction {
                         resource_type.scope().to_uppercase(),
                         resource_type.service(),
                         resource_type.type_name(),
-                    ).replace("\"", "");
+                    )
+                    .replace("\"", "");
                     return Err(TransmuteError::new(format!(
                         "{name} is not a valid property type for resource type {resource_type}"
                     )));

--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -372,7 +372,7 @@ impl ResourceInstruction {
     ) -> Result<Vec<Self>, TransmuteError> {
         let mut instructions = Vec::with_capacity(parse_tree.len());
 
-        for (name, attributes) in parse_tree {
+        for (resource_name, attributes) in parse_tree {
             let resource_type = ResourceType::parse(&attributes.resource_type)?;
             let resource_spec = schema.resource_type(&attributes.resource_type);
 
@@ -390,8 +390,8 @@ impl ResourceInstruction {
 
             let mut properties =
                 IndexMap::with_capacity_and_hasher(attributes.properties.len(), Hasher::default());
-            for (name, prop) in attributes.properties {
-                let property_type = resource_spec.and_then(|spec| spec.property(&name));
+            for (prop_name, prop) in attributes.properties {
+                let property_type = resource_spec.and_then(|spec| spec.property(&prop_name));
                 let property_type = property_type.map(|prop| prop.value_type);
                 if property_type.is_none() {
                     let resource_type = format!(
@@ -402,7 +402,7 @@ impl ResourceInstruction {
                     )
                     .replace('\"', "");
                     return Err(TransmuteError::new(format!(
-                        "{name} is not a valid property for resource type {resource_type}"
+                        "{prop_name} is not a valid property for resource {resource_name} of type {resource_type}"
                     )));
                 }
                 let translator = ResourceTranslator {
@@ -410,11 +410,11 @@ impl ResourceInstruction {
                     origins,
                     value_type: property_type,
                 };
-                properties.insert(name, translator.translate(prop)?);
+                properties.insert(prop_name, translator.translate(prop)?);
             }
 
             let mut instruction = Self {
-                name,
+                name: resource_name,
                 condition: attributes.condition,
                 metadata,
                 update_policy,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -757,7 +757,9 @@ fn test_parse_tree_resource_with_fn_and() {
 }
 
 #[test]
-#[should_panic(expected = "ReadEndpoint is not a valid property for resource RDSCluster of type AWS::RDS::DBCluster")]
+#[should_panic(
+    expected = "ReadEndpoint is not a valid property for resource RDSCluster of type AWS::RDS::DBCluster"
+)]
 fn test_invalid_resource_property() {
     let cfn_template = json!({
         "Resources": {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ use cdk_from_cfn::parser::parameters::{Parameter, ParameterType};
 use cdk_from_cfn::parser::resource::{DeletionPolicy, IntrinsicFunction};
 use cdk_from_cfn::parser::resource::{ResourceAttributes, ResourceValue};
 use cdk_from_cfn::primitives::WrapperF64;
-use cdk_from_cfn::{CloudformationParseTree, TransmuteError};
+use cdk_from_cfn::CloudformationParseTree;
 use indexmap::IndexMap;
 use std::borrow::Cow;
 use std::vec;


### PR DESCRIPTION
In the event that an invalid property is specified for a specific resource type the `value_type` will be `None` causing the `other` arm of the match statement below to execute.

https://github.com/cdklabs/cdk-from-cfn/blob/2c14390f73b765b961a71b0cc2952fe87af587fb/src/ir/resources/mod.rs#L119-L129

Due to the `unimplemented!` macro panicking in-place, a non-descriptive error message is displayed while using cdk migrate:

```
cdk migrate --from-path './CDKMigrateExampleTemplate.yml' --stack-name CustomStackName
...
 ❌  Migrate failed for `CustomStackName`: stack generation failed due to error 'unreachable'

stack generation failed due to error 'unreachable'
```

This PR adds a new explicit check for the case where `property_type` is `None`. If that case is true, then a more descriptive error message will be displayed explaining what resource property is not valid. For example,

```
cdk migrate --from-path './CDKMigrateExampleTemplate.yml' --stack-name CustomStackName
...
 ❌  Migrate failed for `CustomStackName`: stack generation failed due to error 'ReadEndpoint is not a valid resource property for resource RDSCluster of type AWS::RDS::DBCluster'

stack generation failed due to error 'ReadEndpoint is not a valid resource property for resource RDSCluster of type AWS::RDS::DBCluster'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
