### PR TITLE
chore: derive debug for `CloudformationProgramIr`

### DIFF
--- a/src/ir/constructor/mod.rs
+++ b/src/ir/constructor/mod.rs
@@ -2,6 +2,7 @@ use crate::{parser::parameters::Parameter, Hasher};
 use indexmap::IndexMap;
 use voca_rs::case::camel_case;
 
+#[derive(Debug)]
 pub struct Constructor {
     pub inputs: Vec<ConstructorParameter>,
 }
@@ -42,6 +43,7 @@ impl Constructor {
     }
 }
 
+#[derive(Debug)]
 pub struct ConstructorParameter {
     pub name: String,
     pub description: Option<String>,

--- a/src/ir/mappings/mod.rs
+++ b/src/ir/mappings/mod.rs
@@ -4,6 +4,7 @@ use crate::ir::mappings::OutputType::{Complex, Consistent};
 use crate::parser::lookup_table::{MappingInnerValue, MappingTable};
 use crate::Hasher;
 
+#[derive(Debug)]
 pub struct MappingInstruction {
     pub name: String,
     pub map: IndexMap<String, IndexMap<String, MappingInnerValue, Hasher>, Hasher>,

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -20,6 +20,7 @@ pub mod reference;
 pub mod resources;
 pub mod sub;
 
+#[derive(Debug)]
 pub struct CloudformationProgramIr {
     pub description: Option<String>,
     pub transforms: Vec<String>,


### PR DESCRIPTION
This PR adds the ability to be able print the `CloudformationProgramIr`. This is helpful while implementing new features and while fixing bugs because we're able to see the `CloudformationProgramIr` structure and data types while developing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
