### PR TITLE
chore: temporarily don't block on codecov

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Submit Coverage to CodeCov
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/codecov.json
           name: codecov.json


### PR DESCRIPTION
This should stop codecov from blocking merges when it can't upload the results.

Once we get the configuration fixed, we will change this back to true. Dependency upgrades shouldn't be impacting codecov anyway.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
