### PR TITLE
chore: automate daily import of the patched CloudFormation schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,10 @@ jobs:
           branch: github-actions/release
           base: main
           body: |
-            release: <%= crate.name %> v<%= version.actual %>
-
+            release: cdk-from-cfn
             [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          commit-message: |-
-            release: <%= crate.name %> v<%= version.actual %>
-
-            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
           title: |
-            release: <%= crate.name %> v<%= version.actual %>
+            chore: release cdk-from-cfn
           labels: auto-approve
       - name: Push New Tag
         run: git push origin --tags

--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -1,0 +1,51 @@
+name: schema-sync
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # An hour before the daily release sync
+    - cron: 0 23 * * *
+
+jobs:
+  generate:
+    name: Generate Patched Schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+      - name: Set Git Identity
+        run: |-
+          git config user.name "cdklabs-automation"
+          git config user.email "aws-cdk-dev+cdklabs@amazon.com"
+      - name: Setup Node
+        uses: actions/setup-node@main
+        with:
+          node-version: '*'
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8196'
+      - name: Pull and Patch Schema
+        id: pull_and_patch
+        uses: cdklabs/cdk-patched-schema-generator@main
+        with:
+          output-path: '/home/runner/work/cdk-from-cfn/cdk-from-cfn/src/specification'
+      - name: Show Diff
+        run: 'git diff'
+      - name: Open Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          author: cdklabs-automation <aws-cdk-dev+cdklabs@amazon.com>
+          committer: cdklabs-automation <aws-cdk-dev+cdklabs@amazon.com>
+          signoff: true
+          branch: github-actions/update-schema
+          body: |
+            Updates CloudFormation Specification. See details in [workflow run].
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit-message: |-
+            chore: upgrade cloudformation specification
+            Updates CloudFormation Specification. See details in [workflow run].
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          title: 'chore: update cloudformation specification'
+          labels: auto-approve


### PR DESCRIPTION
This is the schema we use to translate CloudForamation templates into CDK apps. This change pulls in daily updates.

This should not be merged until the GitHub action is fully setup.

This also includes a change to the formatting of the release PR because it annoyed me. The templating language never worked but we never took the time to fix it or remove it.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
