### PR TITLE
chore: appease clippy violations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "bytes-utils"

--- a/src/ir/sub/mod.rs
+++ b/src/ir/sub/mod.rs
@@ -34,7 +34,7 @@ pub fn sub_parse_tree(str: &str) -> Result<Vec<SubValue>, crate::Error> {
 /// inner_resolver will do one of the following:
 /// * take until you see a ${ which is the start of the variable bits.
 /// * take something like ${ ... }
-/// TODO -- there are some Sub strings that will escape the $, that are not captured yet.
+///   TODO -- there are some Sub strings that will escape the $, that are not captured yet.
 ///         Will need to rewrite the parse tree to handle character escapes.
 fn inner_resolver(str: &str) -> IResult<&str, SubValue> {
     // Due to the caller being many1, we will need to create out own EOF error to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
-
 use indexmap::IndexMap;
 use parser::condition::ConditionFunction;
 use parser::lookup_table::MappingTable;

--- a/src/parser/resource/mod.rs
+++ b/src/parser/resource/mod.rs
@@ -96,7 +96,7 @@ impl<'de> serde::de::Deserialize<'de> for ResourceValue {
                             entry.insert(data.next_value()?);
                         }
                         Entry::Occupied(entry) => {
-                            return Err(A::Error::custom(&format!(
+                            return Err(A::Error::custom(format!(
                                 "duplicate object key {key:?}",
                                 key = entry.key()
                             )))

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -932,22 +932,6 @@ fn name(key: &str) -> String {
         .collect()
 }
 
-trait JavaCodeBuffer {
-    fn java_doc(&self) -> Rc<CodeBuffer>;
-}
-
-impl JavaCodeBuffer for CodeBuffer {
-    #[inline]
-    fn java_doc(&self) -> Rc<CodeBuffer> {
-        self.indent_with_options(IndentOptions {
-            indent: " * ".into(),
-            leading: Some("/**".into()),
-            trailing: Some(" */".into()),
-            trailing_newline: true,
-        })
-    }
-}
-
 pub struct JavaConstructorParameter {
     pub name: String,
     pub description: Option<String>,

--- a/tests/end-to-end/app-boilerplate-files/csharp/CSharp.csproj
+++ b/tests/end-to-end/app-boilerplate-files/csharp/CSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>


### PR DESCRIPTION
Fixes clippy lint breaking

Removed some unused code, along with small safe fixes from clippy. Clippy continuously updates what it sees as redundant or not Rust idiomatic, and 1.80 added a few more to the list that are safe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
