### PR TITLE
fix: allow translation of doubles from strings

### DIFF
--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -85,11 +85,20 @@ impl<'a, 'b> ResourceTranslator<'a, 'b> {
                             }
                         })?)),
                         Primitive::Number => {
-                            Ok(ResourceIr::Number(s.parse().map_err(|cause| {
-                                Error::ResourceTranslationError {
-                                    message: format!("{cause}"),
-                                }
-                            })?))
+                            let ir = match s.contains(".") {
+                                true => ResourceIr::Double(WrapperF64::new(s.parse().map_err(
+                                    |cause| Error::ResourceTranslationError {
+                                        message: format!("{cause}"),
+                                    },
+                                )?)),
+                                false => ResourceIr::Number(s.parse().map_err(|cause| {
+                                    Error::ResourceTranslationError {
+                                        message: format!("{cause}"),
+                                    }
+                                })?),
+                            };
+
+                            Ok(ir)
                         }
                         _ => Ok(ResourceIr::String(s)),
                     };

--- a/src/ir/resources/tests.rs
+++ b/src/ir/resources/tests.rs
@@ -8,6 +8,7 @@ use crate::ir::reference::{Origin, Reference};
 use crate::ir::resources::{order, ResourceInstruction, ResourceIr, ResourceType};
 use crate::ir::ReferenceOrigins;
 use crate::parser::resource::{IntrinsicFunction, ResourceValue};
+use crate::primitives::WrapperF64;
 use crate::Hasher;
 
 use super::{Primitive, ResourceTranslator, Schema, TypeReference};
@@ -198,7 +199,7 @@ fn test_boolean_parse_error() {
 }
 
 #[test]
-fn test_number_parse_error() {
+fn test_number_parse_float() {
     let origins = ReferenceOrigins {
         origins: HashMap::default(),
     };
@@ -208,6 +209,21 @@ fn test_number_parse_error() {
         value_type: Some(TypeReference::Primitive(Primitive::Number)),
     };
     let resource_value = ResourceValue::String("1.5".into());
+    let result = translator.translate(resource_value).unwrap();
+    assert_eq!(ResourceIr::Double(WrapperF64::new(1.5)), result);
+}
+
+#[test]
+fn test_number_parse_error() {
+    let origins = ReferenceOrigins {
+        origins: HashMap::default(),
+    };
+    let translator = ResourceTranslator {
+        schema: &Schema::builtin(),
+        origins: &origins,
+        value_type: Some(TypeReference::Primitive(Primitive::Number)),
+    };
+    let resource_value = ResourceValue::String("15abc".into());
     let result = translator.translate(resource_value).unwrap_err();
     assert_eq!("invalid digit found in string", result.to_string());
 }

--- a/tests/end-to-end/cloudwatch/csharp/Stack.cs
+++ b/tests/end-to-end/cloudwatch/csharp/Stack.cs
@@ -39,7 +39,7 @@ namespace CloudwatchStack
                 MetricName = "5XXError",
                 ComparisonOperator = "GreaterThanThreshold",
                 Statistic = "Average",
-                Threshold = 0,
+                Threshold = 0.005,
                 Period = 900,
                 EvaluationPeriods = 1,
                 TreatMissingData = "notBreaching",

--- a/tests/end-to-end/cloudwatch/csharp/Stack.diff
+++ b/tests/end-to-end/cloudwatch/csharp/Stack.diff
@@ -1,5 +1,5 @@
 diff --git a/./tests/end-to-end/cloudwatch/template.json b/tests/end-to-end/cloudwatch-csharp-working-dir/cdk.out/Stack.template.json
-index 8d26c7b..aad44e9 100644
+index 30a1dd6..fd7e22a 100644
 --- a/./tests/end-to-end/cloudwatch/template.json
 +++ b/tests/end-to-end/cloudwatch-csharp-working-dir/cdk.out/Stack.template.json
 @@ -1,50 +1,28 @@
@@ -38,11 +38,10 @@ index 8d26c7b..aad44e9 100644
 +    "EvaluationPeriods": 1,
      "MetricName": "5XXError",
 -        "ComparisonOperator": "GreaterThanThreshold",
+-        "Statistic": "Average",
+-        "Threshold": "0.005",
 +    "Namespace": "AWS/ApiGateway",
-+    "Period": 900,
-     "Statistic": "Average",
-     "Threshold": 0,
--        "Period": 900,
+     "Period": 900,
 -        "EvaluationPeriods": 1,
 -        "TreatMissingData": "notBreaching",
 -        "AlarmActions": [
@@ -59,6 +58,8 @@ index 8d26c7b..aad44e9 100644
 -            }
 -          }
 -        ]
++    "Statistic": "Average",
++    "Threshold": 0.005,
 +    "TreatMissingData": "notBreaching"
     }
    }

--- a/tests/end-to-end/cloudwatch/csharp/Stack.template.json
+++ b/tests/end-to-end/cloudwatch/csharp/Stack.template.json
@@ -21,7 +21,7 @@
     "Namespace": "AWS/ApiGateway",
     "Period": 900,
     "Statistic": "Average",
-    "Threshold": 0,
+    "Threshold": 0.005,
     "TreatMissingData": "notBreaching"
    }
   }

--- a/tests/end-to-end/cloudwatch/golang/stack.go
+++ b/tests/end-to-end/cloudwatch/golang/stack.go
@@ -41,7 +41,7 @@ func NewCloudwatchStack(scope constructs.Construct, id string, props *Cloudwatch
 			MetricName: jsii.String("5XXError"),
 			ComparisonOperator: jsii.String("GreaterThanThreshold"),
 			Statistic: jsii.String("Average"),
-			Threshold: jsii.Number(0),
+			Threshold: jsii.Number(0.005),
 			Period: jsii.Number(900),
 			EvaluationPeriods: jsii.Number(1),
 			TreatMissingData: jsii.String("notBreaching"),

--- a/tests/end-to-end/cloudwatch/java/Stack.diff
+++ b/tests/end-to-end/cloudwatch/java/Stack.diff
@@ -1,5 +1,5 @@
 diff --git a/./tests/end-to-end/cloudwatch/template.json b/tests/end-to-end/cloudwatch-java-working-dir/cdk.out/Stack.template.json
-index 8d26c7b..aad44e9 100644
+index 30a1dd6..fd7e22a 100644
 --- a/./tests/end-to-end/cloudwatch/template.json
 +++ b/tests/end-to-end/cloudwatch-java-working-dir/cdk.out/Stack.template.json
 @@ -1,50 +1,28 @@
@@ -38,11 +38,10 @@ index 8d26c7b..aad44e9 100644
 +    "EvaluationPeriods": 1,
      "MetricName": "5XXError",
 -        "ComparisonOperator": "GreaterThanThreshold",
+-        "Statistic": "Average",
+-        "Threshold": "0.005",
 +    "Namespace": "AWS/ApiGateway",
-+    "Period": 900,
-     "Statistic": "Average",
-     "Threshold": 0,
--        "Period": 900,
+     "Period": 900,
 -        "EvaluationPeriods": 1,
 -        "TreatMissingData": "notBreaching",
 -        "AlarmActions": [
@@ -59,6 +58,8 @@ index 8d26c7b..aad44e9 100644
 -            }
 -          }
 -        ]
++    "Statistic": "Average",
++    "Threshold": 0.005,
 +    "TreatMissingData": "notBreaching"
     }
    }

--- a/tests/end-to-end/cloudwatch/java/Stack.template.json
+++ b/tests/end-to-end/cloudwatch/java/Stack.template.json
@@ -21,7 +21,7 @@
     "Namespace": "AWS/ApiGateway",
     "Period": 900,
     "Statistic": "Average",
-    "Threshold": 0,
+    "Threshold": 0.005,
     "TreatMissingData": "notBreaching"
    }
   }

--- a/tests/end-to-end/cloudwatch/java/src/main/java/com/myorg/Stack.java
+++ b/tests/end-to-end/cloudwatch/java/src/main/java/com/myorg/Stack.java
@@ -38,7 +38,7 @@ class CloudwatchStack extends Stack {
                 .metricName("5XXError")
                 .comparisonOperator("GreaterThanThreshold")
                 .statistic("Average")
-                .threshold(0)
+                .threshold(0.005)
                 .period(900)
                 .evaluationPeriods(1)
                 .treatMissingData("notBreaching")

--- a/tests/end-to-end/cloudwatch/python/Stack.diff
+++ b/tests/end-to-end/cloudwatch/python/Stack.diff
@@ -1,5 +1,5 @@
 diff --git a/./tests/end-to-end/cloudwatch/template.json b/tests/end-to-end/cloudwatch-python-working-dir/cdk.out/Stack.template.json
-index 8d26c7b..aad44e9 100644
+index 30a1dd6..fd7e22a 100644
 --- a/./tests/end-to-end/cloudwatch/template.json
 +++ b/tests/end-to-end/cloudwatch-python-working-dir/cdk.out/Stack.template.json
 @@ -1,50 +1,28 @@
@@ -38,11 +38,10 @@ index 8d26c7b..aad44e9 100644
 +    "EvaluationPeriods": 1,
      "MetricName": "5XXError",
 -        "ComparisonOperator": "GreaterThanThreshold",
+-        "Statistic": "Average",
+-        "Threshold": "0.005",
 +    "Namespace": "AWS/ApiGateway",
-+    "Period": 900,
-     "Statistic": "Average",
-     "Threshold": 0,
--        "Period": 900,
+     "Period": 900,
 -        "EvaluationPeriods": 1,
 -        "TreatMissingData": "notBreaching",
 -        "AlarmActions": [
@@ -59,6 +58,8 @@ index 8d26c7b..aad44e9 100644
 -            }
 -          }
 -        ]
++    "Statistic": "Average",
++    "Threshold": 0.005,
 +    "TreatMissingData": "notBreaching"
     }
    }

--- a/tests/end-to-end/cloudwatch/python/Stack.template.json
+++ b/tests/end-to-end/cloudwatch/python/Stack.template.json
@@ -21,7 +21,7 @@
     "Namespace": "AWS/ApiGateway",
     "Period": 900,
     "Statistic": "Average",
-    "Threshold": 0,
+    "Threshold": 0.005,
     "TreatMissingData": "notBreaching"
    }
   }

--- a/tests/end-to-end/cloudwatch/python/stack.py
+++ b/tests/end-to-end/cloudwatch/python/stack.py
@@ -25,7 +25,7 @@ class CloudwatchStack(Stack):
           metric_name = '5XXError',
           comparison_operator = 'GreaterThanThreshold',
           statistic = 'Average',
-          threshold = 0,
+          threshold = 0.005,
           period = 900,
           evaluation_periods = 1,
           treat_missing_data = 'notBreaching',

--- a/tests/end-to-end/cloudwatch/template.json
+++ b/tests/end-to-end/cloudwatch/template.json
@@ -27,7 +27,7 @@
         "MetricName": "5XXError",
         "ComparisonOperator": "GreaterThanThreshold",
         "Statistic": "Average",
-        "Threshold": 0,
+        "Threshold": "0.005",
         "Period": 900,
         "EvaluationPeriods": 1,
         "TreatMissingData": "notBreaching",

--- a/tests/end-to-end/cloudwatch/typescript/Stack.diff
+++ b/tests/end-to-end/cloudwatch/typescript/Stack.diff
@@ -1,5 +1,5 @@
 diff --git a/./tests/end-to-end/cloudwatch/template.json b/tests/end-to-end/cloudwatch-typescript-working-dir/cdk.out/Stack.template.json
-index 8d26c7b..aad44e9 100644
+index 30a1dd6..fd7e22a 100644
 --- a/./tests/end-to-end/cloudwatch/template.json
 +++ b/tests/end-to-end/cloudwatch-typescript-working-dir/cdk.out/Stack.template.json
 @@ -1,50 +1,28 @@
@@ -38,11 +38,10 @@ index 8d26c7b..aad44e9 100644
 +    "EvaluationPeriods": 1,
      "MetricName": "5XXError",
 -        "ComparisonOperator": "GreaterThanThreshold",
+-        "Statistic": "Average",
+-        "Threshold": "0.005",
 +    "Namespace": "AWS/ApiGateway",
-+    "Period": 900,
-     "Statistic": "Average",
-     "Threshold": 0,
--        "Period": 900,
+     "Period": 900,
 -        "EvaluationPeriods": 1,
 -        "TreatMissingData": "notBreaching",
 -        "AlarmActions": [
@@ -59,6 +58,8 @@ index 8d26c7b..aad44e9 100644
 -            }
 -          }
 -        ]
++    "Statistic": "Average",
++    "Threshold": 0.005,
 +    "TreatMissingData": "notBreaching"
     }
    }

--- a/tests/end-to-end/cloudwatch/typescript/Stack.template.json
+++ b/tests/end-to-end/cloudwatch/typescript/Stack.template.json
@@ -21,7 +21,7 @@
     "Namespace": "AWS/ApiGateway",
     "Period": 900,
     "Statistic": "Average",
-    "Threshold": 0,
+    "Threshold": 0.005,
     "TreatMissingData": "notBreaching"
    }
   }

--- a/tests/end-to-end/cloudwatch/typescript/stack.ts
+++ b/tests/end-to-end/cloudwatch/typescript/stack.ts
@@ -32,7 +32,7 @@ export class CloudwatchStack extends cdk.Stack {
       metricName: '5XXError',
       comparisonOperator: 'GreaterThanThreshold',
       statistic: 'Average',
-      threshold: 0,
+      threshold: 0.005,
       period: 900,
       evaluationPeriods: 1,
       treatMissingData: 'notBreaching',


### PR DESCRIPTION
There were certain templates that errored out and said "not a valid integer". When looking at the code, it turns out that if a string thinks there is a number -- a number in JSON can be either integer or doable. Originally, the code parsed only ints, so any float/double fails outright. This update now will try both. I'm sure in the future we will need to try to parse one, fail, parse the other -- but for now, just look for a ".".

Fixes #750

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
