### PR TITLE
Revert "chore(deps): bump codecov/codecov-action from 4 to 5 (#747)"

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -76,8 +76,8 @@ jobs:
           cargo llvm-cov report --hide-instantiations --ignore-filename-regex '^(tests/.*\.rs|.*/tests\.rs)$' --codecov --output-path target/codecov.json
           cargo llvm-cov report --hide-instantiations --ignore-filename-regex '^(tests/.*\.rs|.*/tests\.rs)$' --html --output-dir target/coverage
           cargo llvm-cov report --hide-instantiations --ignore-filename-regex '^(tests/.*\.rs|.*/tests\.rs)$'
-      - name: upload-codecov
-        uses: codecov/codecov-action@v5
+      - name: Upload Coverage to CodeCov
+        uses: codecov/codecov-action@v4
         with:
           use_oidc: true
           fail_ci_if_error: true


### PR DESCRIPTION
This reverts commit 6c47b8b6f1e3ab6bcc3bb7aaadc6a532ea11b455.

Fixes broken codecov in my other PR: https://github.com/cdklabs/cdk-from-cfn/pull/751

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
