### PR TITLE
chore: current version of `cargo-release` is not installable

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           crate: cargo-release
           # Last version to support the Rust version we're using
-          version: 0.25.13  
+          version: 0.25.11  
 
       - name: Prepare git identity
         run: |


### PR DESCRIPTION
The `Daily Release Check` workflow is failing with:

```console
Run baptiste0928/cargo-install@v3
Installing cargo-release...
  Fetching information for cargo-release from index ...
  Warning: New version for cargo-release available: 0.25.[15](https://github.com/cdklabs/cdk-from-cfn/actions/runs/12642594859/job/35230670983#step:5:16)
  Installation settings:
     version: 0.25.13
     path: /home/runner/.cargo-install/cargo-release
     key: cargo-install-cargo-release-0.25.13-f2b21f4ec7854a6977ea1ffc
     command: cargo install cargo-release --force --root /home/runner/.cargo-install/cargo-release --version 0.25.13 --locked
No cached version found, installing cargo-release using cargo...
  /home/runner/.cargo/bin/cargo install cargo-release --force --root /home/runner/.cargo-install/cargo-release --version 0.25.13 --locked
      Updating crates.io index
  error: cannot install package `cargo-release 0.25.13`, it requires rustc 1.80 or newer, while the currently active rustc version is 1.78.0
  `cargo-release 0.25.11` supports rustc 1.78
  Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
  Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
      at _ExecState._setResult (/home/runner/work/_actions/baptiste0928/cargo-install/v3/dist/index.js:19333:22)
      at _ExecState.CheckComplete (/home/runner/work/_actions/baptiste0928/cargo-install/v3/dist/index.js:19319:[16](https://github.com/cdklabs/cdk-from-cfn/actions/runs/12642594859/job/35230670983#step:5:17))
      at ChildProcess.<anonymous> (/home/runner/work/_actions/baptiste0928/cargo-install/v3/dist/index.js:19222:21)
      at ChildProcess.emit (node:events:5[19](https://github.com/cdklabs/cdk-from-cfn/actions/runs/12642594859/job/35230670983#step:5:20):28)
      at maybeClose (node:internal/child_process:1105:16)
      at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

Looking at [crates.io](https://crates.io/crates/cargo-release/versions), indeed it shows that version `0.25.13` only support rust 1.80. This is weird because we explicitly [set](https://github.com/cdklabs/cdk-from-cfn/pull/785) it to `0.25.13` for the same reason. And indeed we did have [successful runs](https://github.com/cdklabs/cdk-from-cfn/actions/runs/12614854380) of this workflow with `0.25.13`. 

Not sure what happened - maybe it got retagged on `creates.io`? In any case, lets use the version it currently recommends, which is 0.25.11

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
