### PR TITLE
chore: update codecov-action to v5

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -110,7 +110,7 @@ jobs:
           cargo llvm-cov report --hide-instantiations --ignore-filename-regex '^(tests/.*\.rs|.*/tests\.rs)$'
 
       - name: Upload Coverage to CodeCov
-        uses: codecov/codecov-action@v4.5.0
+        uses: codecov/codecov-action@v5
         with:
           use_oidc: true
           fail_ci_if_error: true


### PR DESCRIPTION
Previously blocked due to bugs in the latest major version. They should now be fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
