### PR TITLE
fix: prevent codecov upload failure from blocking CI

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -113,7 +113,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: target/codecov.json
           name: codecov.json
 


### PR DESCRIPTION
Prevents codecov from blocking CI, until they fix the following:

https://github.com/codecov/codecov-action/issues/1806
https://github.com/codecov/codecov-action/pull/1792

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
