### PR TITLE
fix: re-enable blocking changes that fail codecov

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -113,7 +113,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           files: target/codecov.json
           name: codecov.json
 


### PR DESCRIPTION
Resolution of https://github.com/codecov/codecov-action/issues/1806 prevents codecov uploads from breaking now.

Fixes #908 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
