### PR TITLE
fix: typescript tests are using npx for ts-node instead of version in node modules

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -100,9 +100,6 @@ jobs:
         run: |
           sudo rm -rf /tmp/.dotnet
 
-      - name: NPM Install 
-        run: npm install -g
-
       - name: Tests with Coverage
         run: just test-cov
 

--- a/cdk-from-cfn-testing/boilerplate/typescript/cdk.json
+++ b/cdk-from-cfn-testing/boilerplate/typescript/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "NODE_PATH=${NODE_PATH:-$PROJECT_ROOT/cdk-from-cfn-testing/.shared_installations/node_modules} npx ts-node --transpile-only ./app.ts"
+  "app": "NODE_PATH=${NODE_PATH:-$PROJECT_ROOT/cdk-from-cfn-testing/.shared_installations/node_modules} ${NODE_PATH:-$PROJECT_ROOT/cdk-from-cfn-testing/.shared_installations/node_modules}/.bin/ts-node --transpile-only ./app.ts"
 }

--- a/cdk-from-cfn-testing/build.rs
+++ b/cdk-from-cfn-testing/build.rs
@@ -64,8 +64,15 @@ fn install_python(shared_dir: &PathBuf) {
     let python_venv = shared_dir.join(".python-venv");
     if !python_venv.exists() {
         println!("cargo:warning=Creating Python venv");
-        Command::new("python3").args(["-m", "venv"]).arg(&python_venv).output().ok();
-        Command::new(python_venv.join("bin/pip")).args(["install", "-q", "-r", "boilerplate/python/requirements.txt"]).output().ok();
+        Command::new("python3")
+            .args(["-m", "venv"])
+            .arg(&python_venv)
+            .output()
+            .ok();
+        Command::new(python_venv.join("bin/pip"))
+            .args(["install", "-r", "boilerplate/python/requirements.txt"])
+            .output()
+            .ok();
     }
 }
 
@@ -115,8 +122,16 @@ fn install_typescript(shared_dir: &PathBuf) {
     let cdk_bin = shared_dir.join("node_modules/.bin/cdk");
     if !cdk_bin.exists() {
         println!("cargo:warning=Installing npm packages");
-        std::fs::copy("boilerplate/typescript/package.json", shared_dir.join("package.json")).ok();
-        Command::new("npm").args(["install", "--silent"]).current_dir(shared_dir).output().ok();
+        std::fs::copy(
+            "boilerplate/typescript/package.json",
+            shared_dir.join("package.json"),
+        )
+        .ok();
+        Command::new("npm")
+            .args(["install", "--prefer-offline", "--no-audit"])
+            .current_dir(shared_dir)
+            .output()
+            .ok();
     }
 }
 
@@ -157,4 +172,3 @@ fn zip_test_snapshots() -> io::Result<()> {
     println!("cargo:rustc-env=END_TO_END_SNAPSHOTS={}", out_file.display());
     Ok(())
 }
-


### PR DESCRIPTION
This change does three things:
1. Uses the shared installation of ts-node instead of using npx
2. removes the silent flags for python and npm installations (the others didn't have those flags). This only prints if you use `-- --nocapture` so it won't make the logs more noisy on it's own, but it also will provide progress of shared installations if the user wants them.
3. Adds `--prefer-offline` and `--no-audit` to the npm installations so that it prioritizes use of the local cache instead of new downloads and skips security checks (these are temporary downloads just for the tests)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
