### PR TITLE
chore: remove NPM token reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,5 +95,5 @@ jobs:
       - name: Release
         if: steps.published.outputs.published == 'false'
         run: |-
-          npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
+          # Should use trusted publishing
           wasm-pack publish --tag latest


### PR DESCRIPTION
Hopefully this makes NPM fall back to trusted publishing automatically. The NPM package is configured correctly already.

Fixes #

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
