### PR TITLE
fix: deserialize shorthand-tagged intrinsics in Fn::Not and Fn::Sub

### DIFF
--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -249,19 +249,84 @@ impl<'de> serde::Deserialize<'de> for ConditionValue {
     }
 }
 
-#[derive(serde::Deserialize)]
-#[serde(untagged)]
-enum Singleton {
-    Value(ConditionValue),
-    SingletonTuple((ConditionValue,)),
-}
+// `Fn::Not` takes its operand either as a bare condition value or wrapped in a
+// single-element list. This was previously modeled with `#[serde(untagged)]`,
+// but serde's untagged deserialization buffers the input through `Content` and
+// then refuses enum input ("untagged and internally tagged enums do not support
+// enum input"). serde_yaml surfaces shorthand tags such as `!Equals` AS enum
+// input, so `!Not [!Equals [...]]` failed to parse. Deserializing the inner
+// `ConditionValue` directly — it has its own visitor that understands tags —
+// avoids the buffering entirely.
+struct Singleton(ConditionValue);
 
 impl Singleton {
     fn unwrap(self) -> ConditionValue {
-        match self {
-            Self::Value(value) => value,
-            Self::SingletonTuple((value,)) => value,
+        self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Singleton {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SingletonVisitor;
+        impl<'de> serde::de::Visitor<'de> for SingletonVisitor {
+            type Value = ConditionValue;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a condition value or a single-element list containing one")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let value: ConditionValue = match seq.next_element()? {
+                    Some(value) => value,
+                    None => return Err(A::Error::invalid_length(0, &self)),
+                };
+                // `Fn::Not` takes exactly one operand; drain any extras.
+                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                Ok(value)
+            }
+
+            // Bare (non-list) scalar forms mirror ConditionValue's own handling.
+            fn visit_str<E: Error>(self, val: &str) -> Result<Self::Value, E> {
+                Ok(ConditionValue::String(val.into()))
+            }
+            fn visit_bool<E: Error>(self, val: bool) -> Result<Self::Value, E> {
+                Ok(ConditionValue::String(val.to_string()))
+            }
+            fn visit_i64<E: Error>(self, val: i64) -> Result<Self::Value, E> {
+                Ok(ConditionValue::String(val.to_string()))
+            }
+            fn visit_u64<E: Error>(self, val: u64) -> Result<Self::Value, E> {
+                Ok(ConditionValue::String(val.to_string()))
+            }
+            fn visit_f64<E: Error>(self, val: f64) -> Result<Self::Value, E> {
+                Ok(ConditionValue::String(val.to_string()))
+            }
+
+            // Bare (non-list) tagged/map forms delegate to ConditionValue.
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                map: A,
+            ) -> Result<Self::Value, A::Error> {
+                <ConditionValue as serde::Deserialize>::deserialize(
+                    serde::de::value::MapAccessDeserializer::new(map),
+                )
+            }
+            fn visit_enum<A: serde::de::EnumAccess<'de>>(
+                self,
+                data: A,
+            ) -> Result<Self::Value, A::Error> {
+                <ConditionValue as serde::Deserialize>::deserialize(
+                    serde::de::value::EnumAccessDeserializer::new(data),
+                )
+            }
         }
+
+        deserializer
+            .deserialize_any(SingletonVisitor)
+            .map(Singleton)
     }
 }
 

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -283,29 +283,41 @@ impl<'de> serde::Deserialize<'de> for Singleton {
                     Some(value) => value,
                     None => return Err(A::Error::invalid_length(0, &self)),
                 };
-                // `Fn::Not` takes exactly one operand; drain any extras.
-                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                // `Fn::Not` takes exactly one operand; a trailing element means
+                // a malformed template, so surface it instead of dropping it.
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(A::Error::invalid_length(2, &self));
+                }
                 Ok(value)
             }
 
-            // Bare (non-list) scalar forms mirror ConditionValue's own handling.
+            // Every non-list form delegates to `ConditionValue` so the two
+            // deserializers can't drift apart.
             fn visit_str<E: Error>(self, val: &str) -> Result<Self::Value, E> {
-                Ok(ConditionValue::String(val.into()))
+                <ConditionValue as serde::Deserialize>::deserialize(
+                    serde::de::value::StrDeserializer::new(val),
+                )
             }
             fn visit_bool<E: Error>(self, val: bool) -> Result<Self::Value, E> {
-                Ok(ConditionValue::String(val.to_string()))
+                <ConditionValue as serde::Deserialize>::deserialize(
+                    serde::de::value::BoolDeserializer::new(val),
+                )
             }
             fn visit_i64<E: Error>(self, val: i64) -> Result<Self::Value, E> {
-                Ok(ConditionValue::String(val.to_string()))
+                <ConditionValue as serde::Deserialize>::deserialize(
+                    serde::de::value::I64Deserializer::new(val),
+                )
             }
             fn visit_u64<E: Error>(self, val: u64) -> Result<Self::Value, E> {
-                Ok(ConditionValue::String(val.to_string()))
+                <ConditionValue as serde::Deserialize>::deserialize(
+                    serde::de::value::U64Deserializer::new(val),
+                )
             }
             fn visit_f64<E: Error>(self, val: f64) -> Result<Self::Value, E> {
-                Ok(ConditionValue::String(val.to_string()))
+                <ConditionValue as serde::Deserialize>::deserialize(
+                    serde::de::value::F64Deserializer::new(val),
+                )
             }
-
-            // Bare (non-list) tagged/map forms delegate to ConditionValue.
             fn visit_map<A: serde::de::MapAccess<'de>>(
                 self,
                 map: A,

--- a/src/parser/condition/tests.rs
+++ b/src/parser/condition/tests.rs
@@ -107,6 +107,52 @@ fn function_not_nested_shorthand() {
 }
 
 #[test]
+fn function_not_bare_operand_delegates_to_condition_value() {
+    // A bare (non-list) `Fn::Not` operand is handled by delegating to
+    // ConditionValue, which covers the scalar / map / enum visitor arms.
+    let not = |v| Box::new(ConditionFunction::Not(v));
+
+    // scalars -> ConditionValue::String
+    assert_eq!(
+        not(ConditionValue::String("foo".into())),
+        serde_yaml::from_str("!Not foo").unwrap(),
+    );
+    assert_eq!(
+        not(ConditionValue::String("-5".into())),
+        serde_yaml::from_str("!Not -5").unwrap(),
+    );
+    assert_eq!(
+        not(ConditionValue::String("5".into())),
+        serde_yaml::from_str("!Not 5").unwrap(),
+    );
+    assert_eq!(
+        not(ConditionValue::String("1.5".into())),
+        serde_yaml::from_str("!Not 1.5").unwrap(),
+    );
+
+    // map form (visit_map) and shorthand-tag form (visit_enum)
+    let equals = ConditionValue::Function(Box::new(ConditionFunction::Equals(
+        ConditionValue::String("a".into()),
+        ConditionValue::String("b".into()),
+    )));
+    assert_eq!(
+        not(equals.clone()),
+        serde_yaml::from_str(r#"Fn::Not: {Fn::Equals: ["a", "b"]}"#).unwrap(),
+    );
+    assert_eq!(
+        not(equals),
+        serde_yaml::from_str(r#"Fn::Not: !Equals ["a", "b"]"#).unwrap(),
+    );
+}
+
+#[test]
+fn function_not_rejects_malformed_operand_lists() {
+    // `Fn::Not` takes exactly one operand: neither zero nor more than one.
+    serde_yaml::from_str::<Box<ConditionFunction>>("!Not []").unwrap_err();
+    serde_yaml::from_str::<Box<ConditionFunction>>("!Not [true, false]").unwrap_err();
+}
+
+#[test]
 fn condition_function_and() {
     let expected = ConditionValue::Function(Box::new(ConditionFunction::And(vec![
         ConditionValue::String("true".into()),

--- a/src/parser/condition/tests.rs
+++ b/src/parser/condition/tests.rs
@@ -85,6 +85,28 @@ fn function_not() {
 }
 
 #[test]
+fn function_not_nested_shorthand() {
+    // Regression: a shorthand-tagged intrinsic nested under `!Not` previously
+    // failed to deserialize with "untagged and internally tagged enums do not
+    // support enum input", because the `Not` operand was an untagged enum.
+    let expected = Box::new(ConditionFunction::Not(ConditionValue::Function(Box::new(
+        ConditionFunction::Equals(
+            ConditionValue::Ref("Foo".into()),
+            ConditionValue::String("bar".into()),
+        ),
+    ))));
+
+    assert_eq!(
+        expected,
+        serde_yaml::from_str("!Not [!Equals [!Ref Foo, bar]]").unwrap(),
+    );
+    assert_eq!(
+        expected,
+        serde_yaml::from_str("Fn::Not: [{Fn::Equals: [{Ref: Foo}, bar]}]").unwrap(),
+    );
+}
+
+#[test]
 fn condition_function_and() {
     let expected = ConditionValue::Function(Box::new(ConditionFunction::And(vec![
         ConditionValue::String("true".into()),

--- a/src/parser/intrinsics/mod.rs
+++ b/src/parser/intrinsics/mod.rs
@@ -255,7 +255,11 @@ impl<'de> serde::Deserialize<'de> for SubPayload {
                 };
                 // The second element (the variables map) is optional.
                 let variables: Option<ResourceValue> = seq.next_element()?;
-                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                // `Fn::Sub` is `template` or `[template, variables]`; a third
+                // element means a malformed template, so surface it.
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(A::Error::invalid_length(3, &self));
+                }
                 Ok(SubPayload(template, variables))
             }
         }

--- a/src/parser/intrinsics/mod.rs
+++ b/src/parser/intrinsics/mod.rs
@@ -214,20 +214,52 @@ impl StringOrPair {
     }
 }
 
-#[derive(Debug, serde::Deserialize)]
-#[serde(untagged)]
-enum SubPayload {
-    String(String),
-    SingletonList((String,)),
-    StringAndObject(String, Option<ResourceValue>),
-}
+// `Fn::Sub` is either a bare template string or `[template, {variables}]`. This
+// was previously modeled with `#[serde(untagged)]`, which buffers through
+// `Content` and then refuses enum input ("untagged and internally tagged enums
+// do not support enum input"). A variables map whose values are shorthand tags
+// (`!Ref`, `!GetAtt`, ...) is exactly such enum input, so it failed to parse.
+// Deserializing the parts directly (ResourceValue handles tags) avoids buffering.
+struct SubPayload(String, Option<ResourceValue>);
 
 impl SubPayload {
     fn into_pair(self) -> (String, Option<ResourceValue>) {
-        match self {
-            Self::String(string) => (string, None),
-            Self::SingletonList((string,)) => (string, None),
-            Self::StringAndObject(string, object) => (string, object),
+        (self.0, self.1)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SubPayload {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SubVisitor;
+        impl<'de> serde::de::Visitor<'de> for SubVisitor {
+            type Value = SubPayload;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a Sub template string or a [template, variables] list")
+            }
+
+            fn visit_str<E: Error>(self, val: &str) -> Result<Self::Value, E> {
+                Ok(SubPayload(val.to_string(), None))
+            }
+            fn visit_string<E: Error>(self, val: String) -> Result<Self::Value, E> {
+                Ok(SubPayload(val, None))
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let template: String = match seq.next_element()? {
+                    Some(template) => template,
+                    None => return Err(A::Error::invalid_length(0, &self)),
+                };
+                // The second element (the variables map) is optional.
+                let variables: Option<ResourceValue> = seq.next_element()?;
+                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                Ok(SubPayload(template, variables))
+            }
         }
+
+        deserializer.deserialize_any(SubVisitor)
     }
 }

--- a/src/parser/resource/tests.rs
+++ b/src/parser/resource/tests.rs
@@ -351,6 +351,28 @@ fn intrinsic_sub() {
 }
 
 #[test]
+fn intrinsic_sub_shorthand_tagged_variable() {
+    // Regression: a `Fn::Sub` whose variables map contains a shorthand-tagged
+    // intrinsic (`!Ref`) previously failed to deserialize with "untagged and
+    // internally tagged enums do not support enum input", because the Sub
+    // payload was an untagged enum.
+    assert_eq!(
+        ResourceValue::from_value(
+            serde_yaml::from_str(r#"!Sub ["${Foo}", { Foo: !Ref Bar }]"#).unwrap()
+        )
+        .unwrap(),
+        IntrinsicFunction::Sub {
+            string: "${Foo}".into(),
+            replaces: Some(ResourceValue::Object(IndexMap::from_iter([(
+                "Foo".to_string(),
+                IntrinsicFunction::Ref("Bar".to_string()).into(),
+            )]))),
+        }
+        .into(),
+    );
+}
+
+#[test]
 fn intrinsic_ref() {
     const LOGICAL_NAME: &str = "LogicalName";
 

--- a/src/parser/resource/tests.rs
+++ b/src/parser/resource/tests.rs
@@ -373,6 +373,16 @@ fn intrinsic_sub_shorthand_tagged_variable() {
 }
 
 #[test]
+fn intrinsic_sub_rejects_malformed_element_lists() {
+    // `Fn::Sub` is `template` or `[template, variables]`: not empty, and not 3+.
+    ResourceValue::from_value(serde_yaml::from_str(r#"!Sub []"#).unwrap()).unwrap_err();
+    ResourceValue::from_value(
+        serde_yaml::from_str(r#"!Sub ["${Foo}", { Foo: !Ref Bar }, "extra"]"#).unwrap(),
+    )
+    .unwrap_err();
+}
+
+#[test]
 fn intrinsic_ref() {
     const LOGICAL_NAME: &str = "LogicalName";
 


### PR DESCRIPTION
Refs #694, aws/aws-cdk-cli#824

## Problem

Migrating CloudFormation templates that use YAML shorthand intrinsics in two common places fails with:

```
... could not be generated because <path>: untagged and internally tagged enums do not support enum input
```

Two spots in the parser model their payloads as `#[serde(untagged)]` enums:

- `Singleton` — the operand of `Fn::Not`
- `SubPayload` — the `Fn::Sub` `[template, {variables}]` form

serde's untagged deserialization buffers the input through `Content` and then refuses *enum* input, but `serde_yaml` surfaces YAML shorthand tags (`!Equals`, `!Ref`, `!GetAtt`, …) as enum input. So a shorthand intrinsic nested under `Fn::Not`, or inside a `Fn::Sub` variables map, fails to parse — e.g.:

```yaml
# condition operand
!Not [!Equals [!Ref Foo, ""]]
# Sub variables map
!Sub ["${Foo}", { Foo: !Ref Bar }]
```

## Fix

Replace both untagged enums with hand-written `Deserialize` impls that deserialize the inner `ConditionValue` / `ResourceValue` directly. Those types already have visitors that understand YAML tags, so deserializing them directly avoids the `Content` buffering that rejected the tagged input. Behavior for the previously-working forms (bare value, single-element list, `[template, {literals}]`) is preserved.

This is parser-only and language-agnostic — no synthesizer, IR, or schema changes.

## Scope

This fixes the *deserialization* failure. It does not change which intrinsic functions are permitted *inside* a `Conditions` block — e.g. `Fn::Join`/`Fn::Sub` used inside a condition is a separate gap. That's why this references #694 rather than closing it.

## Testing

- Added regression tests `function_not_nested_shorthand` (conditions) and `intrinsic_sub_shorthand_tagged_variable` (resources).
- `cargo test --all-features` — all tests pass.
- `cargo fmt --check` and `cargo clippy --tests -- -Adead-code -Dwarnings -Dclippy::dbg_macro` — clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
