### PR TITLE
fix: resolve clippy lints surfaced by Rust 1.97 toolchain bump

### DIFF
--- a/src/synthesizer/csharp/mod.rs
+++ b/src/synthesizer/csharp/mod.rs
@@ -585,7 +585,7 @@ impl Reference {
                     ))
                 }
             }
-            Origin::LogicalId { conditional: _, .. } => {
+            Origin::LogicalId { .. } => {
                 output.text(format!("{}.Ref", camel_case(&self.name.replace('.', ""))))
             }
             Origin::CfnParameter | Origin::Parameter => {
@@ -908,7 +908,7 @@ impl OutputInstruction {
             leading: Some(
                 format!(
                     "new CfnOutput(this, \"CfnOutput{}\", new CfnOutputProps {{",
-                    &self.name
+                    self.name
                 )
                 .into(),
             ),
@@ -916,7 +916,7 @@ impl OutputInstruction {
             trailing_newline: true,
         });
 
-        output.line(format!("Key = \"{}\",", &self.name));
+        output.line(format!("Key = \"{}\",", self.name));
         if let Some(description) = &self.description {
             output.line(format!("Description = \"{}\",", description.escape_debug()));
         }

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -760,8 +760,7 @@ impl ImportInstruction {
 
         Ok(format!(
             "{} \"{}\"",
-            &self
-                .service
+            self.service
                 .as_ref()
                 .unwrap_or(&"cdk".to_string())
                 .to_lowercase(),

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -551,14 +551,14 @@ impl<'a> Java<'a> {
                         leading: Some(
                             format!(
                                 "CfnOutput.Builder.create(this, \"CfnOutput{}\")",
-                                &output.name
+                                output.name
                             )
                             .into(),
                         ),
                         trailing: Some(format!("{DOUBLE_INDENT}.build();").into()),
                         trailing_newline: true,
                     });
-                    output_writer.line(format!(".key(\"{}\")", &output.name));
+                    output_writer.line(format!(".key(\"{}\")", output.name));
                     output_writer.line(format!(".value(this.{var_name}.toString())"));
                     output_writer
                 }
@@ -575,14 +575,14 @@ impl<'a> Java<'a> {
                         leading: Some(
                             format!(
                                 "this.{var_name}.ifPresent(_{var_name} -> CfnOutput.Builder.create(this, \"CfnOutput{}\")",
-                                &output.name
+                                output.name
                             )
                             .into(),
                         ),
                         trailing: Some(format!("{DOUBLE_INDENT}.build());").into()),
                         trailing_newline: true,
                     });
-                    output_writer.line(format!(".key(\"{}\")", &output.name));
+                    output_writer.line(format!(".key(\"{}\")", output.name));
                     output_writer.line(format!(".value(_{var_name}.toString())"));
                     output_writer
                 }

--- a/src/synthesizer/python/mod.rs
+++ b/src/synthesizer/python/mod.rs
@@ -260,12 +260,12 @@ fn emit_cfn_output(
 ) {
     let output = output.indent_with_options(IndentOptions {
         indent: INDENT,
-        leading: Some(format!("cdk.CfnOutput(self, 'CfnOutput{}', ", &op.name).into()),
+        leading: Some(format!("cdk.CfnOutput(self, 'CfnOutput{}', ", op.name).into()),
         trailing: Some(")".into()),
         trailing_newline: true,
     });
 
-    output.line(format!("key = '{}',", &op.name));
+    output.line(format!("key = '{}',", op.name));
     if let Some(description) = &op.description {
         output.line(format!("description = '{}',", description.escape_debug()));
     }
@@ -465,7 +465,7 @@ impl Reference {
                 format!("props['{}'].value_as_string", camel_case(&self.name)).into()
             }
             Origin::Parameter => format!("props['{}']", camel_case(&self.name)).into(),
-            Origin::LogicalId { conditional: _, .. } => {
+            Origin::LogicalId { .. } => {
                 format!("{var}{chain}ref", var = camel_case(&self.name), chain = ".").into()
             }
             Origin::Condition => camel_case(&self.name).into(),

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -465,12 +465,12 @@ fn emit_cfn_output(
 ) {
     let output = output.indent_with_options(IndentOptions {
         indent: INDENT,
-        leading: Some(format!("new cdk.CfnOutput(this, 'CfnOutput{}', {{", &op.name).into()),
+        leading: Some(format!("new cdk.CfnOutput(this, 'CfnOutput{}', {{", op.name).into()),
         trailing: Some("});".into()),
         trailing_newline: true,
     });
 
-    output.line(format!("key: '{}',", &op.name));
+    output.line(format!("key: '{}',", op.name));
     if let Some(description) = &op.description {
         output.line(format!("description: '{}',", description.escape_debug()));
     }


### PR DESCRIPTION
The upcoming Rust 1.97 toolchain bump (#1254 / #1259) fails the Lint and Format check on two new clippy lints. This PR fixes them independently so the check passes.

  Changes (via `cargo clippy --fix`, 5 synthesizer files):
  - Drop redundant & references in format! arguments in typescript, java, golang, csharp
  - Remove redundant explicit field covered by .. in struct patterns for python and csharp
  - 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
